### PR TITLE
Zmieniony cały „Przewodnik po Go”

### DIFF
--- a/content/basics.article
+++ b/content/basics.article
@@ -18,7 +18,7 @@ Zgodnie z przyjętą konwencją, nazwa pakietu jest taka sama jak ostatni elemen
 #appengine: deterministyczne, tak więc za każdym razem gdy puścisz program
 #appengine: `rand.Intn` zwróci on tę samą wartość.
 #appengine:
-#appengine: (By zobaczyć inną liczbę, ustaw odpowiednią wartość ziarna generator liczb; zobacz [[https://golang.org/pkg/math/rand/#Seed][`rand.Seed`]].
+#appengine: (By zobaczyć inną liczbę, ustaw odpowiednią wartość ziarna generatora liczb; zobacz [[https://golang.org/pkg/math/rand/#Seed][`rand.Seed`]].
 #appengine: W playgroundzie czas jest stały, więc będziesz musiał użyć innej wartości jako ziarna do generatora.)
 
 .play basics/packages.go

--- a/content/basics.article
+++ b/content/basics.article
@@ -142,7 +142,7 @@ Podstawowe typy Go to:
 	complex64 complex128
 
 Przykład prezentuje zmienne różnych typów,
-oraz to, że deklaracje zmiennych mogą być „sformatowane” w bloki, tak jak
+oraz to, że deklaracje zmiennych mogą być sformatowane w bloki, tak jak
 instrukcje importowania.
 
 

--- a/content/basics.article
+++ b/content/basics.article
@@ -92,7 +92,7 @@ W Go wartości zwracane mogą posiadać nazwy. Jeśli je mają, to są one trakt
 
 Nazwy wartości zwracanych powinny być tak dobrane, by wyjaśniały ich znaczenie.
 
-Instrukcja `return` bez żadnych argumentów zwraca nazwane wartości zwracana. Mówi wtedy on "nagiej" instrukcji return (ang. "naked" return)
+Instrukcja `return` bez żadnych argumentów zwraca nazwane wartości. Mówimy wtedy o "nagiej" instrukcji return (ang. "naked" return)
 
 Naga instrukcja return powinna być używana tylko w krótkich funkcjach, takich jak ta w podanym przykładzie. W przeciwny razie jej użycie może pogorszyć czytelność długich funkcji.
 

--- a/content/basics.article
+++ b/content/basics.article
@@ -18,8 +18,8 @@ Zgodnie z przyjętą konwencją, nazwa pakietu jest taka sama jak ostatni elemen
 #appengine: deterministyczne, tak więc za każdym razem gdy puścisz program
 #appengine: `rand.Intn` zwróci on tę samą wartość.
 #appengine:
-#appengine: (By zobaczyć inną liczbę, ustaw odpowiednie wartość ziarna generator liczb; zobacz [[https://golang.org/pkg/math/rand/#Seed][`rand.Seed`]].
-#appengine: W playgroundzie czas jest stałą, więc będziesz musiał użyć innej wartości jako ziarna do generatora.)
+#appengine: (By zobaczyć inną liczbę, ustaw odpowiednią wartość ziarna generator liczb; zobacz [[https://golang.org/pkg/math/rand/#Seed][`rand.Seed`]].
+#appengine: W playgroundzie czas jest stały, więc będziesz musiał użyć innej wartości jako ziarna do generatora.)
 
 .play basics/packages.go
 
@@ -38,7 +38,7 @@ Jednak częścią dobrego stylu programowania w Go jest używanie sformatowanych
 
 * Nazwy eksportowane (ang. exported names)
 
-W Go nazwa jest eksportowana, gdy zaczyna od dużej litery.
+W Go nazwa jest eksportowana, gdy zaczyna się od dużej litery.
 Na przykład, `Pizza` jest nazwą eksportowaną, tak samo jak `Pi`, które jest eksportowane z pakietu `math`.
 
 `pizza` oraz `pi` nie zaczynają się od dużej litery, więc nie są eksportowane.
@@ -88,13 +88,13 @@ Funkcja `swap` zwraca dwa stringi.
 
 * Nazwane wartości zwracane
 
-W Go wartości zwracane mogą posiadać nazwy. Jeśli ją mają, to są one traktowane jako zmienne zdefiniowane na samej górze funkcji.
+W Go wartości zwracane mogą posiadać nazwy. Jeśli je mają, to są one traktowane jako zmienne zdefiniowane na samej górze funkcji.
 
 Nazwy wartości zwracanych powinny być tak dobrane, by wyjaśniały ich znaczenie.
 
 Instrukcja `return` bez żadnych argumentów zwraca nazwane wartości zwracana. Mówi wtedy on "nagiej" instrukcji return (ang. "naked" return)
 
-Naga instrukcja return powinna być używana tylko w krótkich funkcjach, takich jak ta w podanym przykładzie. W przeciwny razie jej użycie może pogorszyć czytelność długiej funkcji.
+Naga instrukcja return powinna być używana tylko w krótkich funkcjach, takich jak ta w podanym przykładzie. W przeciwny razie jej użycie może pogorszyć czytelność długich funkcji.
 
 .play basics/named-results.go
 
@@ -110,7 +110,7 @@ Instrukcja `var` może znajdować się na poziomie pakietu lub funkcji. W przyk�
 
 Deklaracja zmiennej może zawierać inicjalizator, po jednym dla każdej zmiennej.
 
-Jeśli inicjalizator jest obecny, podanie typu jest zbędne; zmienna przyjemnie typ inicjalizatora.
+Jeśli inicjalizator jest obecny, podanie typu jest zbędne; zmienna przyjmie typ inicjalizatora.
 
 .play basics/variables-with-initializers.go
 

--- a/content/basics.article
+++ b/content/basics.article
@@ -1,51 +1,50 @@
 Pakiety, zmienne, oraz funkcje.
-Naucz się podstawowych komponentów każdego programu Go.
+Naucz się podstawowych komponentów każdego programu napisanego w Go.
 
 Autorzy Go
 https://golang.org
 
-* Pakiety (tzw. Packages)
+* Pakiety (ang. packages)
 
-Każdy program Go jest stworzony z pakietów.
+Każdy program Go składa się z pakietów.
 
-Programy zaczynają się w pakiecie `main`.
+Programy zaczynają swoje wykonywanie od pakietu `main`.
 
-Ten program używa pakietów z zaimportowanymi ścieżkami `"fmt"` oraz `"math/rand"`.
+Ten program używa pakietów opisanych ścieżkami importowania `"fmt"` oraz `"math/rand"`.
 
-Umownie, deklaracja pakietu jest taka sama jak ostatni element z ścieżki importu. Na przykład, package `"math/rand"` zawiera pliki które zaczynają się od instrukcji `package`rand`.
+Zgodnie z przyjętą konwencją, nazwa pakietu jest taka sama jak ostatni element jego ścieżki importowania. Na przykład, pakiet `"math/rand"` zawiera pliki które zaczynają się od instrukcji `package rand`.
 
 #appengine: *Uwaga:* Środowisko w którym te programy są uruchamiane jest
 #appengine: deterministyczne, tak więc za każdym razem gdy puścisz program
-#appengine: `rand.Intn` zwróci tę samą wartość.
+#appengine: `rand.Intn` zwróci on tę samą wartość.
 #appengine:
-#appengine: (By zobaczyć inną liczbę, podłącz generator liczb; zobacz [[https://golang.org/pkg/math/rand/#Seed][`rand.Seed`]].
-#appengine: W playgroundzie czas jest stałą, więc będziesz musiał użyć czegoś innego do generatora.)
+#appengine: (By zobaczyć inną liczbę, ustaw odpowiednie wartość ziarna generator liczb; zobacz [[https://golang.org/pkg/math/rand/#Seed][`rand.Seed`]].
+#appengine: W playgroundzie czas jest stałą, więc będziesz musiał użyć innej wartości jako ziarna do generatora.)
 
 .play basics/packages.go
 
 * Importy (tzw. Imports)
 
-Ten kod grupuje importy w ścieżki importu które znajdują się w nawiasie. 
+Ten kod grupuje importy w zamknięte w nawiasach, „sformatowane” instrukcje importowania.
 
-Możesz równierz napisać wiele ścieżek importu osobno, na przykład:
+Możesz również napisać kilka osobnych instrukcji importowania, na przykład:
 
 	import "fmt"
 	import "math"
 
-Jednak dobrze jest używać importów uwzględnionych w nawiasie.
+Jednak częścią dobrego stylu programowania w Go jest używanie sformatowanych instrukcji importowania.
 
 .play basics/imports.go
 
-* Nazwy eksportowane (tzw. Exported names)
+* Nazwy eksportowane (ang. exported names)
 
-W Go, nazwa jest eksportowana gdy zaczyna się dużą literą. 
-Na przykład, `Pizza` jest nazwą exportowaną, tak samo jak `Pi`, które eksportowane
-jest z pakietu `math`.
+W Go nazwa jest eksportowana, gdy zaczyna od dużej litery.
+Na przykład, `Pizza` jest nazwą eksportowaną, tak samo jak `Pi`, które jest eksportowane z pakietu `math`.
 
-`pizza` oraz `pi` nie zaczynają się dużą literą, więc nie są eksportowane.
+`pizza` oraz `pi` nie zaczynają się od dużej litery, więc nie są eksportowane.
 
-Gdy importujesz pakiety, możesz odnieść się tylko do ich nazw eksportowanych.
-Jakiekolwiek nazwy które nie są eksportowane, są nie dostępne poza pakietem.
+Gdy importujesz pakiety, możesz odnosić się tylko do nazw które eksportują.
+Wszystkie „nieeksportowane” nazwy nie są dostępne poza pakietem w którym zostały zdefiniowane.
 
 Uruchom kod. Zauważ jaki błąd zwrócił.
 
@@ -53,7 +52,7 @@ By naprawić ten błąd, zmień nazwę `math.pi` na `math.Pi` i spróbuj ponowni
 
 .play basics/exported-names.go
 
-* Funkcje (tzw. Functions)
+* Funkcje (ang. functions)
 
 Funkcja może przyjąć zero lub więcej argumentów.
 
@@ -61,65 +60,65 @@ W tym przykładzie, `add` przyjmuje dwa parametry o typie `int`.
 
 Zauważ że typ podany jest _po_ nazwie zmiennej.
 
-(By dowiedzieć się więcej dlaczego typy wyglądają tak a nie inaczej, zobacz [[https://blog.golang.org/gos-declaration-syntax][artykuł dotyczący składni deklaracji Go]].)
+(By dowiedzieć się więcej dlaczego typy wyglądają tak a nie inaczej, zobacz [[https://blog.golang.org/gos-declaration-syntax][artykuł dotyczący składni deklaracji w Go]].)
 
 .play basics/functions.go
 
 * Funkcje ciąg dalszy
 
-Gdy dwie lub więcej kolejnych parametrów funkcji są tego samego typu, możesz pominąć podanie typu na wszystkich parametrach, prócz ostatniego.
+Gdy dwa lub więcej kolejnych parametrów funkcji są tego samego typu, możesz pominąć podawanie typu po każdy z parametrów, umieszczając go tylko po ostatnim z nich.
 
-W tym przykładzie, skrócilismy:
+W tym przykładzie, skróciliśmy:
 
 	x int, y int
 
-na
+do
 
 	x, y int
 
 .play basics/functions-continued.go
 
-* Zwracanie wielu wyników
+* Zwracanie wielu wartości
 
-Funkcja może zwrócić jakąkolwiek liczbe rezultatów.
+Funkcja może zwrócić dowolną liczbę wartości.
 
-Funkcja `swap` zwraca dwa strings.
+Funkcja `swap` zwraca dwa stringi.
 
 .play basics/multiple-results.go
 
-* Nazwane wartości zwrotne
+* Nazwane wartości zwracane
 
-W Go wartości zwrócone mogą być nazwane. Jeśli są, są one traktowane jako zmienne zdefiniowane na samej górze funkcji. 
+W Go wartości zwracane mogą posiadać nazwy. Jeśli ją mają, to są one traktowane jako zmienne zdefiniowane na samej górze funkcji.
 
-Nazwy tych zwrotnych powinny być użyte tak, by udokumentować znaczenie wartości zwrotnych.
+Nazwy wartości zwracanych powinny być tak dobrane, by wyjaśniały ich znaczenie.
 
-Instrukcja `return` bez żadnych argumentów zwraca wartości nazwane. Są one zwane "nagimi" zwrotami (tzw. "naked" return)
+Instrukcja `return` bez żadnych argumentów zwraca nazwane wartości zwracana. Mówi wtedy on "nagiej" instrukcji return (ang. "naked" return)
 
-Instrukcje naked return powinny być używane tylko w krótkich funkcjach, tak jak w przykładzie podanym ponieważ mogą bardzo utrudnić czytelność w długich funkcjach.
+Naga instrukcja return powinna być używana tylko w krótkich funkcjach, takich jak ta w podanym przykładzie. W przeciwny razie jej użycie może pogorszyć czytelność długiej funkcji.
 
 .play basics/named-results.go
 
-* Zmienne (tzw. variables)
+* Zmienne (ang. variables)
 
-Instrukcja `var` deklaruje listę zmiennych; tak jak w liście argumentów funkcji, typ jest ostatni.
+Instrukcja `var` deklaruje listę zmiennych; tak jak w liście argumentów funkcji typ podajemy na samym końcu.
 
 Instrukcja `var` może znajdować się na poziomie pakietu lub funkcji. W przykładzie obok widzimy obie sytuacje.
 
 .play basics/variables.go
 
-* Zmienne z inicjatorami
+* Zmienne z inicjalizatorami
 
-Deklaracja zmiennej może zawierać inicjator, jeden na każdą zmienną.
+Deklaracja zmiennej może zawierać inicjalizator, po jednym dla każdej zmiennej.
 
-Jeśli inicjator jest obecny, podanie typu jest zbędne; zmienna przyjmnie typ inicjatora.
+Jeśli inicjalizator jest obecny, podanie typu jest zbędne; zmienna przyjemnie typ inicjalizatora.
 
 .play basics/variables-with-initializers.go
 
-* Deklarowanie krótkich zmiennych (tzw. short variables)
+* Krótkie deklaracje zmiennych (ang. short variable declarations)
 
-W środku funkcji, `:=` może zostać użyte zamiast deklaracji `var` z domniemanym typem.
+W środku funkcji możemy użyć składni deklaracji `:=` zamiast `var` z domniemanym typem.
 
-Poza funkcją, każda instrukcja rozpoczyna się od słowa klucza (`var`, `func`, i tak dalej), tak więc konstrukt `:=` jest nie dostępny.
+Poza funkcją, każda instrukcja rozpoczyna się od słowa kluczowego (`var`, `func`, i tak dalej), więc nie możemy tam używać składni `:=`.
 
 .play basics/short-variable-declarations.go
 
@@ -143,25 +142,25 @@ Podstawowe typy Go to:
 	complex64 complex128
 
 Przykład prezentuje zmienne różnych typów,
-oraz pakowanie zmiennych w bloki, tak samo jak 
-z instrukcjami importu.
+oraz to, że deklaracje zmiennych mogą być „sformatowane” w bloki, tak jak
+instrukcje importowania.
 
 
-Typy `int`, `uint`, oraz `uintptr` są zazwyczaj 32 bitowe na 32-bitowych systemach i 64 bitowe na systemach 64-bitowych.
-Gdy potrzebna ci wartość liczbowa, powinies użyć `int` chyba że z jakiegoś specyficznego powodu musisz użyć liczby całowitej lub liczby całkowitej bez znaku.
+Typy `int`, `uint`, oraz `uintptr` mają zazwyczaj długość 32 bitów na 32-bitowych systemach i 64 bitów na systemach 64-bitowych.
+Gdy potrzebna ci jest wartość całkowita, powinieneś użyć typu `int`, chyba że z jakiegoś powodu potrzebujesz liczby całkowitej o określonej długości bitów lub liczby całkowitej bez znaku.
 
 .play basics/basic-types.go
 
 * Wartości zerowe
 
-Zmienne zadeklarowane bez jawnej wartości początkowej posiadają 
+Zmienne zadeklarowane bez podania jawnej wartości początkowej przyjmują
 _wartość_zerową_.
 
-Wartość zerowa wynosi:
+Wartości zerowe wynoszą:
 
 - `0` dla typów numerycznych,
-- `false` dla wartości boolean, oraz
-- `""` (pusty string) dla strings.
+- `false` dla typu bool, oraz
+- `""` (pusty string) dla stringów.
 
 .play basics/zero.go
 
@@ -181,22 +180,22 @@ Lub, prościej:
 	f := float64(i)
 	u := uint(f)
 
-W przeciwieństwie do C, przydział pomiędzy poszczególnymi typami wymaga
+W przeciwieństwie do C, przypisywanie do zmiennej o innym typie wymaga
 jawnej konwersji.
-Spróbuj usunąć konwerjse `float64` lub `uint` w przykładzie obok i zobacz co się stanie.
+Spróbuj usunąć konwersje `float64` lub `uint` w przykładzie obok i zobacz co się stanie.
 
 .play basics/type-conversions.go
 
-* Wnioskowanie typów (tzw. Type inference)
+* Wnioskowanie typów (ang. type inference)
 
-Gdy deklarujemy zmienną bez określenia danego typu (poprzez użycie składni deklaracji `:=` lub `var`=`), typ zmiennej zostanie wywnioskowany po przez wartość po prawej stronie.
+Gdy deklarujemy zmienną bez określenia danego typu (poprzez użycie składni deklaracji `:=` lub `var`=`), typ zmiennej zostanie wywnioskowany na podstawie wartość po prawej stronie.
 
-Gdy typ wartości po prawej stronie jest określony, nowo powstała zmienna będzie właśnie tego typu:
+Gdy typ wartości po prawej stronie jest określony, nowo powstała zmienna będzie tego samego typu:
 
 	var i int
 	j := i // j jest int
 
-Gdy jednak wartość po prawej stronie zawiera stałą numeryczną bez podanego typu, nowa zmienna może być `int`, `float64`, lub `complex128`, w zależności od dokladności stałej:
+Jednak gdy wartość po prawej stronie jest stałą numeryczną bez podanego typu, nowa zmienna może mieć typ `int`, `float64`, lub `complex128`, w zależności od dokladności stałej:
 
 	i := 42           // int
 	f := 3.142        // float64
@@ -206,30 +205,30 @@ Spróbuj zmiennic wartość początkową `v` w przykładzie obok i zobacz jak wp
 
 .play basics/type-inference.go
 
-* Stałe (tzw. constants)
+* Stałe (ang. constants)
 
-Stałe są deklarowane podobnie jak zmienne, jednak z `const` słowo kluczem.
+Stałe są deklarowane podobnie jak zmienne, jednak z użyciem słowa kluczowego `const`.
 
-Stałe mogą być znakami, stringami, wartościami boolean, lub wartościami liczbowymi.
+Stałe mogą być znakami tekstowymi, stringami, wartościami boolowskimi lub liczbowymi.
 
 Stałe nie mogą być zadeklarowane przy pomocy składni `:=`.
 
 .play basics/constants.go
 
-* Stałe liczbowe (tzw. numeric constants)
+* Stałe liczbowe (ang. numeric constants)
 
-Stałe liczbowe to wartości o dużej precyzji.
+Stałe liczbowe to _wartości_ o dużej precyzji.
 
-Stała zaincjalizowana bez podania typu posiada typ wymagany przez kontekst.
+Stała zaincjalizowana bez podania typu, przyjmuje typ wymagany przez kontekst w którym jest użyta.
 
 Spróbuj wydrukować `needInt(Big)`.
 
-(`int` może maksymalnie przetrzymać 64-bitową liczbę, oraz czasem mniejszą.)
+(`int` może maksymalnie przechowywać liczbę całkowitą zajmującą 64 bity, w pewnych wypadkach tylko mniejszą.)
 
 .play basics/numeric-constants.go
 
 * Gratulujemy!
 
-Ukończyłeś tą lekcję!
+Ukończyłeś tę lekcję!
 
-Możesz wrócić do listy [[/list][modułów]] by dowiedzieć się czego nauczyć się następnie, lub kontynuować do [[javascript:click('.next-page')][następnej lekcji]].
+Możesz wrócić do listy [[/list][modułów]] by zobaczyć czego więcej możesz się nauczyć, lub od razu przejdź do [[javascript:click('.next-page')][następnej lekcji]].

--- a/content/concurrency.article
+++ b/content/concurrency.article
@@ -1,13 +1,17 @@
-Współbieżność (tzw. concurrency)
+Współbieżność (ang. concurrency)
 
-Go dostarcza możliwość współbierzności jako podstawową część języka. Ta lekcja ją zaprezentuje oraz przedstawi przykłady które mogą zostać użyte.
+W Go współbieżności jedną z podstawowych część języka. Ta lekcja prezentuje
+gorutyny oraz kanały i jak można ich użyć, by zaimplementować różne
+schematy współbieżności.
 
 Autorzy Go
 https://golang.org
 
-* Gorutyny (tzw. goroutines)
+* Gorutyny (ang. goroutines)
 
-_gorutyna_ jest lekkim wątkiem którym zarządza stos wywołań Go.
+W Go _gorutyna_ jest wydajnym wątkiem którymi zarządza biblioteka runtime.
+
+Kod
 
 	go f(x, y, z)
 
@@ -15,19 +19,23 @@ rozpoczyna nową gorutynę:
 
 	f(x, y, z)
 
-Ewaluacja `f`, `x`, `y` oraz `z` ma miejsce w współbierznej gorutynie, a egzekucja `f`, w nowej gorutynie.
+Ewaluacja wartości `f`, `x`, `y` oraz `z` odbywa się w obecnej gorutynie, a wykonanie funkcji `f` już nowej.
 
-Gorutyny działają w tej samej przesteni adresowej, tak więc dostęp do dzielonej pamięci musi być zsynchronizowany. Pakiet [[https://golang.org/pkg/sync/][`sync`]] dostarcza przydatnych prymitywów, jednak nie będziesz ich tak często potrzebował w Go jako że istnieją inne prymitywy. (Zobacz następny slide).
+Gorutyny działają w tej samej przestrzeni adresowów, tak więc dostęp
+do współdzielonej pamięci musi być zsynchronizowany. Pakiet
+[[https://golang.org/pkg/sync/][`sync`]] dostarcza przydatnych prymitywów,
+jednak nie będziesz ich zbyt często potrzebował, ponieważ Go posiada inne prymitywy stworzone w tym celu. (Zobacz następny slajd.)
 
 .play concurrency/goroutines.go
 
-* Kanały (tzw. channels)
+* Kanały (ang. channels)
 
-Kanały są typami łączników przez które możesz wysyłać i dostawać wartości z użyciem operatora, `<-`.
+Kanały są posiadającymi typ „kablami” przez które możesz przesyłać
+i odbierać wartości używając operatora `<-`.
 
-	ch <- v    // Wysyła v do kanału ch.
-	v := <-ch  // Otrzymuje od ch,
-	           // oraz przypisuje wartość do v.
+	ch <- v    // Wysyłam v do kanału ch.
+	v := <-ch  // Odbiera wartość z kanału ch
+	           // i przypisuje ją do v.
 
 (Przepływ danych odbywa się w kierunku w którym wskazuje strzałka.)
 
@@ -35,54 +43,70 @@ Tak jak mapy oraz wycinki, kanały muszą zostać stworzone przed użyciem:
 
 	ch := make(chan int)
 
-Domyślnie, wysyłający oraz otrzymujący są zablokowane dopóki druga strona nie jest gotowa. To pozwala gorutynom na synchronizację bez jawnej blokady lub zmiennej warunkowej.
+Domyślnie, wysyłanie oraz odbieranie są zablokowane dopóki druga strona nie
+jest gotowa. To pozwala gorutynom na synchronizację bez jawnej blokady
+lub zmiennych warunkowych.
 
-Kod przykładowy sumuje numery w wycinku, rozdzielając pracę pomiędzy dwie gorutyny.
-Tylko gdy obydwie gorutyny ukończą swe kalkulacje, wynik jest obliczany.
+Kod przykładu obok sumuje liczby zawarte w wycinku, rozdzielając pracę
+pomiędzy dwie gorutyny. Gdy obydwie gorutyny ukończą swoje obliczenia,
+wyliczany jest wynik końcowy.
 
 .play concurrency/channels.go
 
-* Kanały buforowane (tzw. buffered channels)
+* Kanały buforowane (ang. buffered channels)
 
-Kanały mogą być _buforowane_. Dostarcz wielkość bufora jako drugi argument `make` by zaincjalizować kanał buforowany:
+Kanały mogą być _buforowane_. Aby zaincjalizować kanał buforowany podaj
+wielkość bufora jako drugi argument funkcji `make`:
 
 	ch := make(chan int, 100)
 
-Wysyła blok do kanału buforowanego tylko gdy bufor jest pełny. Otrzymuje blok gdy bufor jest pusty.
+Wysyłanie do kanału buforowanego wprowadza blokadę tylko gdy bufor jest
+pełny. Odbieranie wprowadza blokadę tylko gdy bufor jest pusty.
 
-Zmodyfikuj przykład by przepełnić bufor i zobacz co się stanie.
+Zmodyfikuj przykład tak by przepełnić bufor i zobacz co się stanie.
 
 .play concurrency/buffered-channels.go
 
-* Range oraz Close
+* Zakres i zamykanie kanału (ang. range, closing of channel)
 
-Wysyłający może zamknąć (`close`) kanał by podkreślić ze nie zostanie wysłana już żadna wartość. Otrzymujący może sprawdzić czy kanał został zamknięty poprzez przypisanie drugiego parametru do swego wyrażenia:
+Przesyłający może zamknąć (ang. `close`) kanał by zasygnalizować, iż do
+danego kanału nie zostanie już przesłana żadna wartość. Odbierając może
+sprawdzić czy kanał został zamknięty poprzez wprowadzenie drugiego parametru
+do wyrażenia odbierającego wartości z kanału:
 
 	v, ok := <-ch
 
-`ok` jest `false` jeśli nie ma więcej wartości do otrzymania oraz gdy kanał został zamknięty.
+Jeśli `ok` przyjmie wartość boolowską `false` to znaczy, że nie ma więcej
+wartości które można odebrać i kanał jest zamknięty.
 
-Pętla `for`i`:=`range`c` otrzymuje wartości z kanału dopóki nie zostanie on zamknięty.
+Pętla `for`i`:=`range`c` cały czas odbiera wartości z kanału `c`, dopóki ten
+nie zostanie zamknięty.
 
-*Uwaga:* Tylko wysyłający powinien zamykać kanał, nigdy otrzymujący. Wysałając do zamkniętego kanału można wywołać panikę.
+*Uwaga:* Tylko wysyłający powinien zamykać kanał, nigdy odbierający. Próba
+wysłania czegoś przez zamkniętego kanału wywołać panikę.
 
-*Kolejna*uwaga:* Kanały nie są jak pliki; tak naprawdę nie musisz ich zamykać. Zamykanie kanałów jest niezbędne tylko wtedy, gdy odbiorca musi wiedzieć że nie dostanie już żadnych więcej wartości, na przykład po to by mógł zakończyć pętlę `range`.
+*Kolejna*uwaga:* Kanały nie są jak pliki; zwykle nie musisz ich zamykać.
+Zamykanie kanałów jest niezbędne tylko wtedy, gdy odbiorca musi wiedzieć,
+że nie dostanie już z niego żadnych więcej wartości, na przykład po to by mógł zakończyć działanie wyrażenia `range` w pętli.
 
 .play concurrency/range-and-close.go
 
 * Select
 
-Instrukcja `select` pozwala gorutynom czekać na rózne operacje.
+Instrukcja `select` pozwala gorutynom oczekiwać w tym samym czasie na sygnał z kilku różnych źródeł
 
-`select` blokuje wykonanie gorutyny dopóki jedna z jego przypadków (case) nie uruchamia się, wtedy uruchamia ten właśnie przypadek. Wybiera przypadek losowo jeżeli więcej niż jeden przypadek spełnia warunki.  
+Instrukcja `select` blokuje działanie gorutyny dopóki jedna z jej warunków
+nie uruchomi się, wówczas wykonuje odpowiadający temu warunkowi przypadek
+(ang. `case`). Jeśli kilka warunków zostaje uruchomionych jednocześnie, `select` wybiera losowo jeden dostępnych przypadków i wykonuje go.
 
 .play concurrency/select.go
 
 * Domyślna selekcja
 
-Przypadek `default` w `select` jest uruchamiany w momencie gdy żaden innych przypadek nie jest gotowy/nie spełnia warunków.
+Przypadek `default` w `select` jest uruchamiany w momencie gdy warunek
+żadnego z dostępnych przypadków nie został uruchomiony w danej chwili.
 
-Użyj przypadku `default` by spróbować wysłać lub otrzymać bez blokowania: 
+Użyj przypadku `default` by wysłać lub otrzymać wartość bez blokowania:
 
 	select {
 	case i := <-c:
@@ -93,13 +117,18 @@ Użyj przypadku `default` by spróbować wysłać lub otrzymać bez blokowania:
 
 .play concurrency/default-selection.go
 
-* Ćwiczenie: Równowartościowe drzewa binarne
+* Ćwiczenie: Równoważne drzewa binarne
 
-Może istnieć wiele różnych równowartościowych drzew binarnych o tej samej sekwencji wartości które przetrzymują. Na przykład, tutaj są dwa drzewa binarne przetrzymujące sekwencję 1, 1, 2, 3, 5, 8, 13. 
+Może istnieć wiele różnych drzew binarnych przechowujących ten sam ciąg
+liczb. Przykładowo, poniżej mamy dwa drzewa binarne przechowujące ciąg
+1, 1, 2, 3, 5, 8, 13.
 
 .image /content/img/tree.png
 
-Funkcja która sprawdza czy oba drzewa binarne przetrzymują tę samą sekwencję jest bardzo skomplikowana w wielu językach. My użyjemy współbierzności Go oraz kanałów by napisać łatwe rozwiązanie.
+Napisanie funkcji która sprawdza czy oba drzewa binarne przechowują ten
+sam ciąg liczb, w wielu języka jest bardzo skomplikowane. My użyjemy
+współbieżności i kanałów Go rozwiązać ten problem w prosty sposób.
+
 Ten przykład używa pakietu `tree`, które definiuje typ:
 
 	type Tree struct {
@@ -110,7 +139,7 @@ Ten przykład używa pakietu `tree`, które definiuje typ:
 
 
 
-Kontynuuj opis na [[javascript:click('.next-page')][następnej stronie]].
+Kontynuuj opis ćwiczenia na [[javascript:click('.next-page')][następnej stronie]].
 
 * Ćwiczenie: Równowartościowe drzewa binarne
 
@@ -118,90 +147,111 @@ Kontynuuj opis na [[javascript:click('.next-page')][następnej stronie]].
 
 *2.* Przetestuj funkcję `Walk`.
 
-Funkcja `tree.New(k)` konstruuje drzewo binarne o strukturze losowej (zawsze posortowanej) przetrzymujące wartości `k`, `2k`, `3k`, ..., `10k`.
+Funkcja `tree.New(k)` konstruuje drzewo binarne o losowej strukturze
+(ale zawsze jest ono posortowane) przetrzymujące wartości
+`k`, `2k`, `3k`, ..., `10k`.
 
-Stwórz nowy kanał `ch` oraz rozpocznij działanie funkcji `Walk`.
+Stwórz nowy kanał `ch` i wywołaj gorutynę przechodzącą przez drzewo:
 
 	go Walk(tree.New(1), ch)
 
-Następnie przeczytaj oraz wydrukuj 10 wartości z kanału. Powinny być to numery 1, 2, 3, ..., 10.
+Następnie odczytaj i wypisz 10 wartości z kanału `ch`. Powinny być to liczby
+1, 2, 3, ..., 10.
 
-*3.* Zaimplementuj funkcję `Same` używając `Walk` by zdereminować czy `t1` oraz `t2` posiadają te same wartości.
+*3.* Zaimplementuj funkcję `Same` używając `Walk` by sprawdzić czy `t1`
+i `t2` posiadają tę same wartości.
 
 *4.* Przetestuj funkcję `Same`.
 
 `Same(tree.New(1),`tree.New(1))` powinno zwrócić true, a `Same(tree.New(1),`tree.New(2))` powinno zwrócić false.
 
-Dokumentacja `Tree` jest dostępna [[https://godoc.org/golang.org/x/tour/tree#Tree][tutaj]].
+Dokumentacja pakietu `Tree` jest dostępna [[https://godoc.org/golang.org/x/tour/tree#Tree][tutaj]].
 
 .play concurrency/exercise-equivalent-binary-trees.go
 
 * sync.Mutex
 
-Widzieliśmy jak wspaniałe do komunikowania pomiędzy gorutynami są kanały.
+Widzieliśmy jak doskonałym narzędzie do komunikowania się pomiędzy
+gorutynami są kanały.
 
-Ale co jeśli nie potrzebujemy komunikacji? Co jeśli po prostu chcemy się upewnić że
-tylko jedna gorutyna może mieć dostęp do zmiennej w tym samym czasie by uniknąć konfliktów?
+Ale co jeśli nie potrzebujemy komunikacji? Co zrobić w sytuacji gdy chcemy
+by tylko jedna gorutyna mogła mieć w danym momencie dostęp do danej
+zmiennej, by unikać konfliktów między gorutynami?
 
-Ten koncept nazwany jest _wzajemnym_wykluczeniem_ (tzw. mutual exclusion), struktura danych która nam to daje, nazwana jest _mutex_.
-Standardowa biblioteka Go dostarcza wzajemne wykluczenie za pomocą pakietu
+Ta koncepcja nosi nazwę jest _wzajemnego wykluczania_ (ang. mutual
+exclusion), a strukturę danych która pozwala nam z niej korzystać zwyczajowo
+nazywamy _mutex_.
+
+Biblioteka standardowa Go dostarcza wzajemne wykluczenie za pomocą typu
 [[https://golang.org/pkg/sync/#Mutex][`sync.Mutex`]] oraz jego dwóch metod:
 
 - `Lock`
 - `Unlock`
 
-Możemy zdefiniować blok kodu który ma być uruchamiany z wzajemnym wykluczniem poprzez otoczenie go 
-wywołaniem do `Lock` oraz `Unlock` - tak jak widać to w metodzie `Inc`.
+Możemy napisać blok kodu który ma będzie wykonywany w trybie wzajemnego
+wykluczania poprzez otoczenie go wywołaniami metod `Lock` i `Unlock`,
+tak jak zostało to pokazane w definicji metody `Inc`.
 
-Możemy równierz użyć `defer` by upewnić się że mutex będzie otwarty (unlocked) tak samo jak widać to w metodzie `Value`.
+Możemy też użyć instrukcji `defer` by upewnić się, że mutex zostanie
+otwarty (ang. unlocked), tak jak widać to w definicji metody `Value`.
 
 .play concurrency/mutex-counter.go
 
 * Ćwiczenie: Web Crawler
 
-W tym ćwiczeniu użyjemy współbierzności Go by równolegle puścić web crawlera.
+W tym ćwiczeniu użyjemy współbieżności języka Go, by zrównoleglić
+działanie web crawlera.
 
-Zmodyfikuj funkcję `Crawl` by odzyskała URLe równolegle bez odzyskiwania tego samego URLa dwa razy.
+Zmodyfikuj funkcję `Crawl` by pobierała adresy URL w sposób równoległy, bez pobierania tego samego adresu URLa dwa razy.
 
- 
-_Podpowiedź_: możesz zachować odzyskane URLe w pamięci podręcznej za pomocą mapy, jedak mapy same w sobie nie są bezpieczne
-do użytku w współbierzności.
+
+_Podpowiedź_: możesz zapisywać pobrane adresy URL w mapie, jednak mapy
+samych w sobie nie można używać w sposób bezpieczny, gdy program jest
+wykonywany w sposób współbieżny!
 
 .play concurrency/exercise-web-crawler.go
 
-* Gdzie udać się dalej...
+* Gdzie się wybrać dalej...
 
-#appengine: Możesz zacząć poprzez
-#appengine: [[https://golang.org/dl/][zainstalowanie Go]].
+#appengine: Możesz zacząć od
+#appengine: [[https://golang.org/dl/][zainstalowania Go]].
 
-#appengine: Gdy już zainstalujesz Go,
+#appengine: Gdy już masz zainstalowane Go, to
 [[https://golang.org/doc/][Dokumentacja Go]] jest świetnym miejscem by
-#appengine: kontynuować.
+#appengine: kontynuować naukę.
 start.
-Zawiera referencje, tutoriale, filmy video, oraz więcej.
+Zawiera odnośniki, tutoriale, filmy video i dużo więcej.
 
-By dowiedzieć się jak zoorganizować oraz pracować z kodem Go, zobacz [[https://www.youtube.com/watch?v=XCsL89YtqCs][to nagranie]] lub przeczytaj [[https://golang.org/doc/code.html][How to Write Go Code]].
+By dowiedzieć się jak zorganizować i jak pracować z kodem w Go, zobacz
+[[https://www.youtube.com/watch?v=XCsL89YtqCs][to nagranie]] lub przeczytaj
+[[https://golang.org/doc/code.html][How to Write Go Code]].
 
-Jeśli potrzebujesz pomocy z biblioteką standardową, zobacz [[https://golang.org/pkg/][package reference]]. Jeśli potrzebujesz pomocy z samym językiem, może cię to zdziwić, ale [[https://golang.org/ref/spec][Language Spec]] jest bardzo przyjemny do poczytania.
+Jeśli potrzebujesz pomocy z biblioteką standardową, zobacz
+[[https://golang.org/pkg/][package reference]]. Jeśli potrzebujesz pomocy
+z samym językiem, może cię to zdziwić, ale
+[[https://golang.org/ref/spec][Language Spec]] (pl. specyfikacja języka)
+jest całkiem przyjemny w czytaniu.
 
-By dalej zwiedzać model wielobierzności w Go, zobacz
+By lepiej poznać model wielobieżności języka Go, obejrzyj
 [[https://www.youtube.com/watch?v=f6kdp27TYZs][Go Concurrency Patterns]]
-([[https://talks.golang.org/2012/concurrency.slide][slidy]])
+([[https://talks.golang.org/2012/concurrency.slide][slajdy z prezentacji]])
 oraz
 [[https://www.youtube.com/watch?v=QDDwwePbDtw][Advanced Go Concurrency Patterns]]
-([[https://talks.golang.org/2013/advconc.slide][slidy]])
+([[https://talks.golang.org/2013/advconc.slide][slajdy z prezentacji]])
 oraz przeczytaj
 [[https://golang.org/doc/codewalk/sharemem/][Share Memory by Communicating]].
 
 By rozpocząć pisanie aplikacji webowych, zobacz
 [[https://vimeo.com/53221558][A simple programming environment]]
 ([[https://talks.golang.org/2012/simple.slide][slidy]])
-oraz przeczytaj
-[[https://golang.org/doc/articles/wiki/][Writing Web Applications]] tutorial.
+oraz przeczytaj tutorial
+[[https://golang.org/doc/articles/wiki/][Writing Web Applications]].
 
-The [[https://golang.org/doc/codewalk/functions/][First Class Functions in Go]] daje interesującą perspektywę dotyczącą funkcji Go.
+Przewodnik po
+kodzie [[https://golang.org/doc/codewalk/functions/][First Class Functions in Go]]
+pokazuję funkcji w Go z ciekawej perspektywy.
 
-The [[https://blog.golang.org/][Go Blog]] posiada duże archiwum bardzo informacyjnych artykułów dotyczących Go.
+Strona [[https://blog.golang.org/][Go Blog]] posiada duże archiwum
+merytorycznych artykułów dotyczących Go.
 
-Odwiedź [[https://golang.org][golang.org]] po więcej.
-
+Jeśli chcesz więcej informacji odwiedź [[https://golang.org][golang.org]].

--- a/content/concurrency.article
+++ b/content/concurrency.article
@@ -1,6 +1,6 @@
 Współbieżność (tzw. concurrency)
 
-Go dostarcza możliwość współbieżności jako podstawową część języka. Ta lekcja ją zaprezentuje oraz przedstawi przykłady które mogą zostać użyte.
+Go dostarcza możliwość współbierzności jako podstawową część języka. Ta lekcja ją zaprezentuje oraz przedstawi przykłady które mogą zostać użyte.
 
 Autorzy Go
 https://golang.org
@@ -15,7 +15,7 @@ rozpoczyna nową gorutynę:
 
 	f(x, y, z)
 
-Ewaluacja `f`, `x`, `y` oraz `z` ma miejsce w współbieżnej gorutynie, a egzekucja `f`, w nowej gorutynie.
+Ewaluacja `f`, `x`, `y` oraz `z` ma miejsce w współbierznej gorutynie, a egzekucja `f`, w nowej gorutynie.
 
 Gorutyny działają w tej samej przesteni adresowej, tak więc dostęp do dzielonej pamięci musi być zsynchronizowany. Pakiet [[https://golang.org/pkg/sync/][`sync`]] dostarcza przydatnych prymitywów, jednak nie będziesz ich tak często potrzebował w Go jako że istnieją inne prymitywy. (Zobacz następny slide).
 
@@ -99,7 +99,7 @@ Może istnieć wiele różnych równowartościowych drzew binarnych o tej samej 
 
 .image /content/img/tree.png
 
-Funkcja która sprawdza czy oba drzewa binarne przetrzymują tę samą sekwencję jest bardzo skomplikowana w wielu językach. My użyjemy współbieżności Go oraz kanałów by napisać łatwe rozwiązanie.
+Funkcja która sprawdza czy oba drzewa binarne przetrzymują tę samą sekwencję jest bardzo skomplikowana w wielu językach. My użyjemy współbierzności Go oraz kanałów by napisać łatwe rozwiązanie.
 Ten przykład używa pakietu `tree`, które definiuje typ:
 
 	type Tree struct {
@@ -159,13 +159,13 @@ Możemy równierz użyć `defer` by upewnić się że mutex będzie otwarty (unl
 
 * Ćwiczenie: Web Crawler
 
-W tym ćwiczeniu użyjemy współbieżności Go by równolegle puścić web crawlera.
+W tym ćwiczeniu użyjemy współbierzności Go by równolegle puścić web crawlera.
 
 Zmodyfikuj funkcję `Crawl` by odzyskała URLe równolegle bez odzyskiwania tego samego URLa dwa razy.
 
  
 _Podpowiedź_: możesz zachować odzyskane URLe w pamięci podręcznej za pomocą mapy, jedak mapy same w sobie nie są bezpieczne
-do użytku w współbieżności.
+do użytku w współbierzności.
 
 .play concurrency/exercise-web-crawler.go
 

--- a/content/concurrency.article
+++ b/content/concurrency.article
@@ -1,15 +1,15 @@
 Współbieżność (ang. concurrency)
 
-W Go współbieżności jedną z podstawowych część języka. Ta lekcja prezentuje
-gorutyny oraz kanały i jak można ich użyć, by zaimplementować różne
-schematy współbieżności.
+W Go współbieżności jest jedną z podstawowych składowych języka. Ta lekcja
+prezentuje gorutyny oraz kanały i jak można ich użyć, by zaimplementować
+różne schematy współbieżności.
 
 Autorzy Go
 https://golang.org
 
 * Gorutyny (ang. goroutines)
 
-W Go _gorutyna_ jest wydajnym wątkiem którymi zarządza biblioteka runtime.
+W Go _gorutyna_ jest wydajnym wątkiem którym zarządza biblioteka runtime.
 
 Kod
 
@@ -24,13 +24,14 @@ Ewaluacja wartości `f`, `x`, `y` oraz `z` odbywa się w obecnej gorutynie, a wy
 Gorutyny działają w tej samej przestrzeni adresowów, tak więc dostęp
 do współdzielonej pamięci musi być zsynchronizowany. Pakiet
 [[https://golang.org/pkg/sync/][`sync`]] dostarcza przydatnych prymitywów,
-jednak nie będziesz ich zbyt często potrzebował, ponieważ Go posiada inne prymitywy stworzone w tym celu. (Zobacz następny slajd.)
+jednak nie będziesz ich zbyt często potrzebował, ponieważ Go posiada inne
+prymitywy stworzone w tym celu. (Zobacz następny slajd.)
 
 .play concurrency/goroutines.go
 
 * Kanały (ang. channels)
 
-Kanały są posiadającymi typ „kablami” przez które możesz przesyłać
+Kanały są posiadającymi typ „kablami” przez które możesz wysyłać
 i odbierać wartości używając operatora `<-`.
 
 	ch <- v    // Wysyłam v do kanału ch.
@@ -69,7 +70,7 @@ Zmodyfikuj przykład tak by przepełnić bufor i zobacz co się stanie.
 
 * Zakres i zamykanie kanału (ang. range, closing of channel)
 
-Przesyłający może zamknąć (ang. `close`) kanał by zasygnalizować, iż do
+Wysyłający może zamknąć (ang. `close`) kanał by zasygnalizować, iż do
 danego kanału nie zostanie już przesłana żadna wartość. Odbierając może
 sprawdzić czy kanał został zamknięty poprzez wprowadzenie drugiego parametru
 do wyrażenia odbierającego wartości z kanału:
@@ -83,17 +84,18 @@ Pętla `for`i`:=`range`c` cały czas odbiera wartości z kanału `c`, dopóki te
 nie zostanie zamknięty.
 
 *Uwaga:* Tylko wysyłający powinien zamykać kanał, nigdy odbierający. Próba
-wysłania czegoś przez zamkniętego kanału wywołać panikę.
+wysłania czegoś przez zamknięty kanał wywoła panikę.
 
 *Kolejna*uwaga:* Kanały nie są jak pliki; zwykle nie musisz ich zamykać.
 Zamykanie kanałów jest niezbędne tylko wtedy, gdy odbiorca musi wiedzieć,
-że nie dostanie już z niego żadnych więcej wartości, na przykład po to by mógł zakończyć działanie wyrażenia `range` w pętli.
+że więcej wartość nie zostanie już nim przesłanych, na przykład po to by
+mógł zakończyć działanie wyrażenia `range` w pętli.
 
 .play concurrency/range-and-close.go
 
 * Select
 
-Instrukcja `select` pozwala gorutynom oczekiwać w tym samym czasie na sygnał z kilku różnych źródeł
+Instrukcja `select` pozwala gorutynom oczekiwać w tym samym czasie na sygnał z kilku różnych źródeł.
 
 Instrukcja `select` blokuje działanie gorutyny dopóki jedna z jej warunków
 nie uruchomi się, wówczas wykonuje odpowiadający temu warunkowi przypadek
@@ -103,8 +105,8 @@ nie uruchomi się, wówczas wykonuje odpowiadający temu warunkowi przypadek
 
 * Domyślna selekcja
 
-Przypadek `default` w `select` jest uruchamiany w momencie gdy warunek
-żadnego z dostępnych przypadków nie został uruchomiony w danej chwili.
+Przypadek `default` w `select` jest uruchamiany w momencie gdy żaden z
+warunków dostępnych przypadków nie został uruchomiony w danej chwili.
 
 Użyj przypadku `default` by wysłać lub otrzymać wartość bez blokowania:
 
@@ -127,7 +129,7 @@ liczb. Przykładowo, poniżej mamy dwa drzewa binarne przechowujące ciąg
 
 Napisanie funkcji która sprawdza czy oba drzewa binarne przechowują ten
 sam ciąg liczb, w wielu języka jest bardzo skomplikowane. My użyjemy
-współbieżności i kanałów Go rozwiązać ten problem w prosty sposób.
+współbieżności i kanałów Go by rozwiązać ten problem w prosty sposób.
 
 Ten przykład używa pakietu `tree`, które definiuje typ:
 
@@ -178,17 +180,18 @@ Ale co jeśli nie potrzebujemy komunikacji? Co zrobić w sytuacji gdy chcemy
 by tylko jedna gorutyna mogła mieć w danym momencie dostęp do danej
 zmiennej, by unikać konfliktów między gorutynami?
 
-Ta koncepcja nosi nazwę jest _wzajemnego wykluczania_ (ang. mutual
+Ta koncepcja nosi nazwę _wzajemnego wykluczania_ (ang. mutual
 exclusion), a strukturę danych która pozwala nam z niej korzystać zwyczajowo
 nazywamy _mutex_.
 
-Biblioteka standardowa Go dostarcza wzajemne wykluczenie za pomocą typu
-[[https://golang.org/pkg/sync/#Mutex][`sync.Mutex`]] oraz jego dwóch metod:
+Biblioteka standardowa Go implementuje mechanizm wzajemnego wykluczania
+za pomocą typu [[https://golang.org/pkg/sync/#Mutex][`sync.Mutex`]]
+oraz jego dwóch metod:
 
 - `Lock`
 - `Unlock`
 
-Możemy napisać blok kodu który ma będzie wykonywany w trybie wzajemnego
+Możemy napisać blok kodu który będzie wykonywany w trybie wzajemnego
 wykluczania poprzez otoczenie go wywołaniami metod `Lock` i `Unlock`,
 tak jak zostało to pokazane w definicji metody `Inc`.
 
@@ -202,7 +205,7 @@ otwarty (ang. unlocked), tak jak widać to w definicji metody `Value`.
 W tym ćwiczeniu użyjemy współbieżności języka Go, by zrównoleglić
 działanie web crawlera.
 
-Zmodyfikuj funkcję `Crawl` by pobierała adresy URL w sposób równoległy, bez pobierania tego samego adresu URLa dwa razy.
+Zmodyfikuj funkcję `Crawl` by pobierała adresy URL w sposób równoległy, bez pobierania tego samego adresu URL dwa razy.
 
 
 _Podpowiedź_: możesz zapisywać pobrane adresy URL w mapie, jednak mapy
@@ -232,7 +235,7 @@ z samym językiem, może cię to zdziwić, ale
 [[https://golang.org/ref/spec][Language Spec]] (pl. specyfikacja języka)
 jest całkiem przyjemny w czytaniu.
 
-By lepiej poznać model wielobieżności języka Go, obejrzyj
+By lepiej poznać model współbieżności języka Go, obejrzyj
 [[https://www.youtube.com/watch?v=f6kdp27TYZs][Go Concurrency Patterns]]
 ([[https://talks.golang.org/2012/concurrency.slide][slajdy z prezentacji]])
 oraz

--- a/content/concurrency.article
+++ b/content/concurrency.article
@@ -34,7 +34,7 @@ prymitywy stworzone w tym celu. (Zobacz następny slajd.)
 Kanały są posiadającymi typ „kablami” przez które możesz wysyłać
 i odbierać wartości używając operatora `<-`.
 
-	ch <- v    // Wysyłam v do kanału ch.
+	ch <- v    // Wysyła v do kanału ch.
 	v := <-ch  // Odbiera wartość z kanału ch
 	           // i przypisuje ją do v.
 

--- a/content/flowcontrol.article
+++ b/content/flowcontrol.article
@@ -1,26 +1,25 @@
-Instrukcje kontroli przepływu: for, if, else, switch oraz defer
-Naucz się jak kontrolować przepływ twego kodu używając warunków (conditionals), pętli (loops), switch oraz defers. 
+Instrukcje sterujące: for, if, else, switch oraz defer
+Naucz się jak kontrolować działaniem twejego kodu używając instrukcji warunkowych (ang. conditionals), pętli (ang. loops), instrukcji switch oraz defer.
 
 Autorzy Go
 https://golang.org
 
 * For
 
-Go posiada tylko jedną konstrukcję pętli, jest nią pętla `for`.
+Go posiada tylko jeden typ pętli, jest nią pętla `for`.
 
-Podstawowa pętla `for` posiada trzy komponenty oddzielone średnikiem:
+Podstawowa pętla `for` posiada trzy składniki oddzielone średnikiem:
 
 - inicjalizacja: odbywa się raz, tuż przez rozpoczęciem pętli
 - wyrażenie warunkowe: sprawdzone przed każdym rozpoczęciem pętli
-- inkrementacja: wykonana po każdym przejściu przez pętlę.
+- inkrementacja: wykonana po każdej iteracji pętli.
 
-Bardzo często, inicjalizacja to krótkie określenie zmiennej lub zmiennych, i owe
-zmienne będą widoczne tylko w bloku danej pętli `for`.
+Bardzo często inicjalizacja jest krótką deklaracja zmiennej lub zmiennych, i owe zmienne będą dostępne tylko wewnątrz bloku danej pętli `for`.
 
-Pętla zakończy iterację gdy tylko wartość boolean zostanie określona jako `false`.
+Pętla zakończy iterację gdy tylko wartość boolowska przyjmie wartość `false`.
 
-*Uwaga:* W odróżnieniu od innych języków takich jak C, Java, lub JavaScript nie używamy nawiasów 
-otaczających trzy komponenty instrukcji `for` jednak `{`}` są zawsze wymagane.
+*Uwaga:* W odróżnieniu od innych języków takich jak C, Java, lub JavaScript nie używamy nawiasów
+otaczających trzy składniki instrukcji `for` jednak `{`}` muszą być zawsze obecne.
 
 .play flowcontrol/for.go
 
@@ -30,30 +29,29 @@ Inicjalizacja oraz inkrementacja są opcjonalne.
 
 .play flowcontrol/for-continued.go
 
-* "for" jest w Go jak "while"
+* "For" jest "while" Go
 
-Używane w C `while` jest tym samym co `for` w Go.
+W tym momencie możesz opuścić średniki: `while` z C jest tym samym co `for` w Go.
 
 .play flowcontrol/for-is-gos-while.go
 
-* Nieskończoność
+* Wieczna pętla
 
-Jeśli ominiesz wyrażenie warunkowe pętli, stworzysz pętle nieskończoną.
+Jeśli ominiesz wyrażenie warunkowe pętli, stworzysz nieskończoną pętle.
 
 .play flowcontrol/forever.go
 
 * If
 
-Instrukcja `if` w Go jest tak jak pętla `for`; wyrażenia nie muszą otaczać nawiasy `(`)`
-jednak `{`}` są wymagane.
+Instrukcja `if` w Go przypomina jego pętlę `for`; wyrażenia boolowskie nie musi być otoczone nawiasami `(`)` jednak `{`}` są wymagane.
 
 .play flowcontrol/if.go
 
 * If z krótką instrukcją
 
-Tak jak `for`, instrukcja `if` może rozpocząć się krótkim wyrażeniem tuż przed warunkiem.
+Tak jak `for`, instrukcja `if` może rozpoczynać się krótką instrukcją umieszczoną tuż przed warunkiem boolowskim.
 
-Zmienne zadeklarowane poprzez wyrażenie są zawarte w bloku tylko do końca `if`.
+Zmienne zadeklarowane poprzez tą instrukcje są dostępne tylko do końca instrukcji `if`.
 
 (Spróbuj użyć `v` w ostatnim wyrażeniu `return`.)
 
@@ -61,71 +59,63 @@ Zmienne zadeklarowane poprzez wyrażenie są zawarte w bloku tylko do końca `if
 
 * If oraz else
 
-Zmienne zadeklarowane w środku krótkiej instrukcji `if` są również dostępne w środku
-każdego bloku `else`.
+Zmienne zadeklarowane w środku krótkiej instrukcji `if` są również dostępne w środku każdego bloku `else`.
 
-(Oba wywołania `pow` zwracają rezultat zanim wywołanie do `fmt.Println` w `main` się zaczyna.)
+(Oba wywołania `pow` zwracają rezultat zanim wywołanie `fmt.Println` w `main` się rozpocznie.)
 
 .play flowcontrol/if-and-else.go
 
-* Ćwiczenie: Pętle oraz Funkcje
+* Ćwiczenie: Pętle oraz funkcje
 
-Jako sposób przećwiczenia funkcji oraz pętli, zaimplementujmy funkcję pierwiastka kwadratowego: posiadając liczbę x, chcemy znaleźć liczbę dla której z² jest najbliższy liczbie x.
+Jako sposób na przećwiczenie funkcji oraz pętli, zaimplementujmy funkcję pierwiastka kwadratowego: posiadając liczbę x, chcemy znaleźć liczbę z, taką że z² jest najbliższe wartości liczby x.
 
 Komputery z reguły obliczają pierwiastek kwadratowy x używając pętli.
-Zaczynając od jakieś przykładowej liczby `z`, możemy dopasować `z` na podstawie tego jak zbliżone z² jest do x,
-ulepszając nasz rezultat:
+Zaczynając od jakieś wybranej liczby `z`, możemy poprawić wartość `z` na podstawie tego jak blisko jest z² do x, ulepszając nasz rezultat:
 
 	z -= (z*z - x) / (2*z)
 
-Poprzez dostosowywanie `z` nasz rezultat powinien wyglądać coraz lepiej,
-aż do momentu gdy otrzymamy odpowiedź najbardziej zbliżoną do pierwiastka kwadratowego.
+Poprzez dopasowywanie `z` nasz rezultat powinien wyglądać coraz lepiej,
+aż do momentu gdy otrzymamy odpowiedź tak zbliżoną do pierwiastka kwadratowego jak się tylko da.
 
-Zaimplementuj to samo używając funkcji `func`Sqrt`.
-Przyzwoitym początkiem dla `z` będzie 1.
-By zacząć, powtórz kalkulację 10 razy i wydrukuj każde `z`.
-Zobacz jak blisko odpowiedzi jestes dla różnych wartości x (1, 2, 3, ...) oraz
-jak szybko rezultat się poprawia.
+Zaimplementuj powyższe rozumowanie w napisanej dla ciebie `func`Sqrt`.
+Przyzwoitym punktem startowym dla dowolnego `z` będzie 1.
+Na początek, powtórz obliczenia 10 razy i wydrukuj każde `z`.
+Zobacz jak blisko odpowiedzi jesteś dla różnych wartości x (1, 2, 3, ...) oraz jak szybko wynik się poprawia.
 
-Wskazówka: By zadeklarować wartość zmiennoprzecinkową (floating point),
-skorzystaj z syntaxu zmiennoprzecinkowego lub użyj konwersji:
+Wskazówka. By zadeklarować wartość zmiennoprzecinkową (ang. floating point value),
+skorzystaj ze składni zmiennoprzecinkowej lub użyj konwersji:
 
 	z := 1.0
 	z := float64(1)
 
-Następnie, zmień warunek pętli tak, by zatrzymała się gdy wartość
-przestanie się zmieniać (lub będzie się zmieniać tylko o bardzo niską wartość).
-Zaobserwuj czy stanie się to po więcej lub mniej niż 10 powtórzeniach.
-Spróbuj również innych wartości podstawowych dla z, x, lub nawet x/2!
-Jak blisko twoja funkcja jest funkcji [[https://golang.org/pkg/math/#Sqrt][math.Sqrt]] ze standardowej biblioteki?
+Następnie, zmień warunek pętli tak, by pętla zatrzymała się gdy obliczana wartość przestanie się zmieniać (lub będzie się zmieniać tylko o bardzo niewielką liczbę).
+Sprawdź czy stanie się to po więcej lub mniej niż 10 iteracjach.
+Wypróbuj inne wartości początkowe dla z, takie jak x, lub x/2.
+Jak blisko wartość zwracana przez twoją funkcję jest tej zwracanej przez funkcję [[https://golang.org/pkg/math/#Sqrt][math.Sqrt]] biblioteki standardowej?
 
-(*Uwaga:* Jeśli jesteś zainteresowany detalami algorytmu, wyżej wymienione z² − x 
-oznacza jak daleko wartość z² jest od wartości którą powinno być (x), podzielenie 2z jest pochodną 
-z², by skalować sposób w jaki dostosowujemy z, w zależności od tego jak szybko zmienia się wartość z²)
+(*Uwaga:* Jeśli jesteś zainteresowany szczegółami działania tego algorytmu, podane wyżej wyrażenie z² − x pokazuje jak daleko wartość z² odbiega od tej jaką powinna mieć (x). Podzielenie 2z, które jest pochodną
+z², przeskalowuje wielkość o jaką poprawiamy z, by uwzględnić to jak szybko zmienia się wartość z².)
 
 To podejście nazywane jest [[https://en.wikipedia.org/wiki/Newton%27s_method][metodą Newtona]].
-Działa ono bardzo dobrze w wielu funkcjach, jednak wyjątkowo dobrze dla pierwiastka kwadratowego.
+Działa ono bardzo dobrze dla wielu funkcjach, jednak wyjątkowo dobrze dla pierwiastka kwadratowego.
 
 .play flowcontrol/exercise-loops-and-functions.go
 
 * Switch
 
-Instrukcja warunkowa `switch` jest krótszym sposobem na zapisanie łańcucha instrukcji `if`-`else`.
-Zostanie wykonany kod którego wynik, zgadza się z warunkiem w instrukcji `switch`.
+Instrukcja warunkowa `switch` jest krótszym sposobem na zapisanie ciągu instrukcji `if`-`else`.
+Wykonuje pierwszy przypadek dla którego wartość jego warunku jest równa wyrażaniu warunkowemu.
 
-Switch w go jest tym samym co w C, C++, Java, JavaScript, oraz PHP,
-z tą różnicą że w Go, puszczany jest tylko przypadek(`case`) który spełnia warunki, a nie 
-wszystkie pozostałe przypadki.
-W efekcie, instrukcja `break` ktora jest wymagana na końcu każdego przypadku w innych językach, 
-w Go dostarczana jest automatycznie.
-Kolejną ważną różnicą jest to, że przypadki w Go nie muszą być stałymi, a wartości przekazywane,
-nie muszą być integerami.
+Switch w Go jest jak to w C, C++, Java, JavaScript, oraz PHP,
+z tą różnicą że w Go, wykonywany jest tylko przypadek (ang. case) który spełnia zadany warunek, a nie również wszystkie pod nim.
+W efekcie, instrukcja `break` która jest wymagana na końcu każdego przypadku w innych językach, w Go dostarczana jest automatycznie.
+Kolejną ważną różnicą jest to, że warunki `switch` w Go nie muszą być stałymi, a wartości porównywane nie muszą być liczbami całkowitymi (ang. integers).
 
 .play flowcontrol/switch.go
 
-* Ewaluacja Switch
+* Porządek wykonywania instrukcji switch
 
-Przypadki switch są ewaluowane od góry do dołu, zatrzymując się gdy przypadek pokrywa się z warunkiem.
+Warunki switch są wykonywane od góry do dołu, procedura zatrzymuje się gdy wartość danego warunku pokrywa się z wartością sprawdzaną.
 
 (Na przykład,
 
@@ -134,43 +124,42 @@ Przypadki switch są ewaluowane od góry do dołu, zatrzymując się gdy przypad
 	case f():
 	}
 
-`f` nie zostanie wykonany jeżeli `i==0`.)
+`f` nie zostanie wykonany jeżeli `i == 0`.)
 
-#appengine: *Uwaga:* Czas w playgroundzie Go zawsze zaczyna się od
-#appengine: 2009-11-10 23:00:00 UTC, wartość której ważność pozastawimy do ustalenia
-#appengine: dla czytelnika.
+#appengine: *Uwaga:* Czas w playgroundzie Go jest liczony od
+#appengine: 2009-11-10 23:00:00 UTC, ustalenie znaczenia tej wartości
+#appengine: pozostawiamy jako ćwiczenie dla czytelnika.
 
 .play flowcontrol/switch-evaluation-order.go
 
-* Switch bezwarunkowy
+* Switch bez głównego warunku
 
-Switch bezwarunkowy jest tym samym co `switch`true`.
+Switch bez głównego warunku jest tym samym co `switch`true`.
 
-Ten konstrukt może być bardzo przejrzystym sposobem na zapisanie długiego łańcucha if-then-else.
+Ta konstrukcja może być bardziej przejrzystym sposobem na zapisanie długiego ciągu if-then-else.
 
 .play flowcontrol/switch-with-no-condition.go
 
-* Defer - czyli opóźnione wykonanie
+* Defer — czyli opóźnione wykonanie
 
-Instrukcja defer opóźnia wykonanie funkcji dopóki otaczająca funkcja nie zwróci wyniku.
+Instrukcja defer opóźnia wykonanie funkcji do momentu gdy otaczająca funkcja nie zwróci wyniku.
 
 Wywołane argumenty w defer są ewaluowane natychmiastowo, jednak sama funkcja
-jest wywołana dopiero gdy otaczająca ją funkcja zwraca wynik.
+jest wywołana dopiero gdy otaczająca ją funkcja zwróci wynik.
 
 .play flowcontrol/defer.go
 
 * Stertowanie defer
 
-Wywołane funkcje deferred są pchnięte do stosu. Gdy funckja zwraca wartość, jej 
-wywołania funkcji deferred są egzekwowane od ostatniej która została wepchnięta do stosu. 
+Funkcje wywołane z instrukcją `defer` są umieszczane na stosie. Po tym jak główna funkcja zwróci wynik, funkcje wywołane wewnątrz niej z instrukcją `defer` z są wykonywane w kolejności od ostatniej do pierwszej która została umieszczona na stosie (LIFO, ang. Last In, First Out).
 
-By nauczyć się więcej o wyrażeniach defer, przeczytaj ten 
-[[https://blog.golang.org/defer-panic-and-recover][blog post]].
+By dowiedzieć się więcej o instrukcji `defer`, przeczytaj ten
+[[https://blog.golang.org/defer-panic-and-recover][artykuł]] na „The Go Blog”.
 
 .play flowcontrol/defer-multi.go
 
 * Gratulujemy!
 
-Ukończyłeś tą lekcję!
+Ukończyłeś tę lekcję!
 
 Możesz wrócić do listy [[/list][modułów]] by dowiedzieć się czego nauczyć się następnie, lub kontynuować do [[javascript:click('.next-page')][następnej lekcji]]

--- a/content/flowcontrol.article
+++ b/content/flowcontrol.article
@@ -67,15 +67,15 @@ Zmienne zadeklarowane w środku krótkiej instrukcji `if` są również dostępn
 
 * Ćwiczenie: Pętle oraz funkcje
 
-Jako sposób na przećwiczenie funkcji oraz pętli, zaimplementujmy funkcję pierwiastka kwadratowego: posiadając liczbę x, chcemy znaleźć liczbę z, taką że z² jest najbliższe wartości liczby x.
+Jako sposób na przećwiczenie funkcji oraz pętli, zaimplementujmy funkcję pierwiastka kwadratowego: mając daną liczbę x, chcemy znaleźć liczbę z, taką że z² jest możliwie najbliższej liczby x.
 
 Komputery z reguły obliczają pierwiastek kwadratowy x używając pętli.
 Zaczynając od jakieś wybranej liczby `z`, możemy poprawić wartość `z` na podstawie tego jak blisko jest z² do x, ulepszając nasz rezultat:
 
 	z -= (z*z - x) / (2*z)
 
-Poprzez dopasowywanie `z` nasz rezultat powinien wyglądać coraz lepiej,
-aż do momentu gdy otrzymamy odpowiedź tak zbliżoną do pierwiastka kwadratowego jak się tylko da.
+Po każdej zmianie `z` nasz rezultat powinien się poprawiać,
+aż do momentu gdy otrzymamy odpowiedź tak zbliżoną do pierwiastka kwadratowego jak tylko jest to możliwe.
 
 Zaimplementuj powyższe rozumowanie w napisanej dla ciebie `func`Sqrt`.
 Przyzwoitym punktem startowym dla dowolnego `z` będzie 1.
@@ -142,7 +142,7 @@ Ta konstrukcja może być bardziej przejrzystym sposobem na zapisanie długiego 
 
 * Defer — czyli opóźnione wykonanie
 
-Instrukcja defer opóźnia wykonanie funkcji do momentu gdy otaczająca funkcja nie zwróci wyniku.
+Instrukcja defer opóźnia wykonanie funkcji do momentu gdy otaczająca funkcja zwróci wyniku.
 
 Wywołane argumenty w defer są ewaluowane natychmiastowo, jednak sama funkcja
 jest wywołana dopiero gdy otaczająca ją funkcja zwróci wynik.
@@ -151,7 +151,7 @@ jest wywołana dopiero gdy otaczająca ją funkcja zwróci wynik.
 
 * Stertowanie defer
 
-Funkcje wywołane z instrukcją `defer` są umieszczane na stosie. Po tym jak główna funkcja zwróci wynik, funkcje wywołane wewnątrz niej z instrukcją `defer` z są wykonywane w kolejności od ostatniej do pierwszej która została umieszczona na stosie (LIFO, ang. Last In, First Out).
+Funkcje wywołane z instrukcją `defer` są umieszczane na stosie. Po tym jak główna funkcja zwróci wynik, funkcje wywołane wewnątrz niej z instrukcją `defer` z są wykonywane w kolejności od ostatniej do pierwszej z nich która została umieszczona na stosie (LIFO, ang. Last In, First Out).
 
 By dowiedzieć się więcej o instrukcji `defer`, przeczytaj ten
 [[https://blog.golang.org/defer-panic-and-recover][artykuł]] na „The Go Blog”.
@@ -162,4 +162,4 @@ By dowiedzieć się więcej o instrukcji `defer`, przeczytaj ten
 
 Ukończyłeś tę lekcję!
 
-Możesz wrócić do listy [[/list][modułów]] by dowiedzieć się czego nauczyć się następnie, lub kontynuować do [[javascript:click('.next-page')][następnej lekcji]]
+Możesz wrócić do listy [[/list][modułów]] by zobaczyć czego więcej możesz się nauczyć, lub od razu przejść do [[javascript:click('.next-page')][następnej lekcji]].

--- a/content/methods.article
+++ b/content/methods.article
@@ -90,7 +90,7 @@ funkcje z argumentem będącym wskaźnikiem mogą przyjmować tylko argumenty b�
 	ScaleFunc(v, 5)  // Compile error!
 	ScaleFunc(&v, 5) // OK
 
-podczas gdy metody z odbiornikiem wskaźnika przyjmują jako swojego odbiorcę zarówno wartość jaki i wskaźnik:
+podczas gdy metody z odbiornikiem wskaźnika przyjmują jako swojego odbiorcę zarówno wartość jak i wskaźnik:
 
 	var v Vertex
 	v.Scale(5)  // OK

--- a/content/methods.article
+++ b/content/methods.article
@@ -9,9 +9,10 @@ https://golang.org
 Go nie posiada klas.
 Jednakże, możesz definiować metody dla danych typów.
 
-Metoda to funkcja ze specjalnym argumentem nazywanym __odbiorcą__ (tzw. _receiver_)
+Metoda to funkcja ze specjalnym argumentem nazywanym _odbiorcą_
+(ang. _receiver_)
 
-Odbiorca pojawia się w swojej własnej liście argumentów pomiędzy słowem `func`
+Odbiorcę podajemy w jego własnej liście argumentów pomiędzy słowem `func`
 a nazwą metody.
 
 W tym przykładzie, metoda `Abs` posiada odbiorcę typu `Vertex` o nazwie `v`.
@@ -20,9 +21,11 @@ W tym przykładzie, metoda `Abs` posiada odbiorcę typu `Vertex` o nazwie `v`.
 
 * Metody to funkcje
 
-Zapamiętaj: metoda to po prostu funkcja posiadają odbiorcę jako swój argument.
+Zapamiętaj: metoda to po prostu funkcja posiadają odbiorcę jako swój
+argument.
 
-Tutaj mamy `Abs` zdefiniowany jako normalna funkcja bez zmian w jej funkcjonalności.
+Tutaj mamy `Abs` zdefiniowany jako normalną funkcję bez zmian w jej
+funkcjonalności.
 
 .play methods/methods-funcs.go
 
@@ -32,33 +35,37 @@ Możesz również zadeklarować metodę na typach nie będących strukturami.
 
 W tym przykładzie, widzimy typ numeryczny `MyFloat` wraz z metodą `Abs`.
 
-Metodę możesz zadeklarować tylko dla odbiorcy którego typ jest zdefiniowany w tym samym pakiecie co metoda.
-Nie możesz zadeklarować metody dla odbiorcy którego typ jest zadeklarowany w innym pakiecie
-(dotyczy to w szczególności wbudowanych typów, takich jak `int`).
+Metodę możesz zadeklarować tylko dla odbiorcy którego typ jest zdefiniowany
+w tym samym pakiecie co metoda.
+Nie możesz zadeklarować metody dla odbiorcy którego typ jest zadeklarowany
+w innym pakiecie (dotyczy to w szczególności wbudowanych typów, takich jak
+`int`).
 
 .play methods/methods-continued.go
 
 * Odbiorcy wskaźników
 
-Możesz zadeklarować metody dla odbiorcy wskaźnika (ang. pointer receivers).
+Możesz zadeklarować metody dla odbiorców wskaźników (ang. pointer receivers).
 
-To oznacza, że typ odbiorncy ma składnię literalną `*T` dla jakiegoś typu `T`.
-(Dodatkowo `T` sam nie może być wskaźnikiem, takim jak przykładowo `*int`.)
+To oznacza, że typ odbiorcy ma składnię literalną `*T` dla jakiegoś typu `T`.
+(Dodatkowo `T` sam nie może być wskaźnikiem, takim jak na przykład `*int`.)
 
 Na przykład, metoda `Scale` zdefiniowana jest dla typu `*Vertex`.
 
 Metody z odbiorcami wskaźników mogą zmieniać wartości które wskazuje odbiorca
 (tak jak `Scale` robi to w tym przykładzie).
-Ponieważ metody często potrzebują zmieniać swojego odbiorcę, odbiorcy wskaźników są dużo
-częściej używani niż odbiorcy wartości.
+Ponieważ metody często potrzebują zmieniać swojego odbiorcę, odbiorcy
+wskaźników są dużo częściej używani niż odbiorcy wartości.
 
-Spróbuj usunąć `*` z deklaracji funkcji `Scale` w linii 16 i zobacz jak zmieni się
-zachowanie programu.
+Spróbuj usunąć `*` z deklaracji funkcji `Scale` w linii 16 i zobacz jak
+zmieni się działanie programu.
 
-Zdefiniowana z odbiorcą wartości, metoda `Scale` operuje na kopii wartości typu `Vertex`.
-(Jest to takie samo zachowanie jak w przypadku wszystkich innych argumentów funkcji.)
-Metoda `Scale` musi posiadać odbiorcę wskaźnika by móc zmienić wartość typu `Vertex` zadeklarowaną
-w funkcji `main`.
+Metoda `Scale` zdefiniowana z odbiorcą wartości operuje na kopii wartości
+typu `Vertex`.
+(Jest to takie samo zachowanie jak w przypadku wszystkich innych argumentów
+funkcji.)
+Metoda `Scale` musi posiadać odbiorcę wskaźnika by móc zmienić wartość typu
+`Vertex` zadeklarowaną w funkcji `main`.
 
 .play methods/methods-pointers.go
 
@@ -67,7 +74,7 @@ w funkcji `main`.
 Tu widzimy metody `Abs` oraz `Scale` zapisane jako funkcje.
 
 Jeszcze raz spróbuj usunąć `*` z linii 16.
-Czy potrafisz dostrzec dlaczego zachowanie programu się zmieniło?
+Czy potrafisz dostrzec dlaczego działanie programu się zmieniło?
 Co jeszcze powinieneś zmienić by przykład się skompilował?
 
 (Jeśli nie jesteś pewien, przejdź do następnej strony.)
@@ -77,14 +84,13 @@ Co jeszcze powinieneś zmienić by przykład się skompilował?
 * Metody oraz dereferencja wskaźników
 
 Porównując dwa poprzednie programy, mogłeś zauważyć że
-funkcje z argumentem będący wskaźnikiem mogą przyjmować tylko wskaźnik:
+funkcje z argumentem będącym wskaźnikiem mogą przyjmować tylko argumenty będące wskaźnikami:
 
 	var v Vertex
 	ScaleFunc(v, 5)  // Compile error!
 	ScaleFunc(&v, 5) // OK
 
-podczas gdy metody z odbiornikiem wskaźnika przyjmują zarówno wartość jaki i wskaźnik jako
-swojego odbiorcą gdy są wywoływane:
+podczas gdy metody z odbiornikiem wskaźnika przyjmują jako swojego odbiorcę zarówno wartość jaki i wskaźnik:
 
 	var v Vertex
 	v.Scale(5)  // OK
@@ -93,8 +99,9 @@ swojego odbiorcą gdy są wywoływane:
 
 W instrukcji `v.Scale(5)`, nawet jeśli `v` jest wartością a nie wskaźnikiem,
 metoda z odbiorcą wskaźnika jest wywołana automatycznie.
-Dzieje się tak, ponieważ dla wygody programowania Go interpretuje instrukcję `v.Scale(5)` jako
-`(&v).Scale(5)`, gdyż metoda `Scale` posiada odbiorcę wskaźnika.
+Dzieje się tak, ponieważ dla wygody programowania Go interpretuje instrukcję
+`v.Scale(5)` jako `(&v).Scale(5)`, gdyż metoda `Scale` posiada odbiorcę
+wskaźnika.
 
 .play methods/indirection.go
 
@@ -102,37 +109,43 @@ Dzieje się tak, ponieważ dla wygody programowania Go interpretuje instrukcję 
 
 To samo dzieje się w odwrotnej sytuacji.
 
-Funkcje które przyjmują jako argument wartość, mogą być wywołane tylko z wartością danego typu:
+Funkcje które przyjmują jako argument wartość, mogą być wywołane tylko
+z wartością danego typu:
 
 	var v Vertex
 	fmt.Println(AbsFunc(v))  // OK
 	fmt.Println(AbsFunc(&v)) // Compile error!
 
-podczas gdy metody z odbiorcą wartości przyjmują zarówno wartość jaki i wskaźniki jako swojego odbiorcę, gdy są wywołane w następujący sposób:
+podczas gdy metody z odbiorcą wartości przyjmują zarówno wartość jaki
+i wskaźniki jako swojego odbiorcę, gdy są wywołane w następujący sposób:
 
 	var v Vertex
 	fmt.Println(v.Abs()) // OK
 	p := &v
 	fmt.Println(p.Abs()) // OK
 
-W takiej sytuacji, wywołanie metody `p.Abs()` jest interpretowane jako `(*p).Abs()`.
+W takiej sytuacji, wywołanie metody `p.Abs()` jest interpretowane jako
+`(*p).Abs()`.
 
 .play methods/indirection-values.go
 
-* Wybranie pomiędzy odbiorcą wartości lub wskaźnika
+* Wybieranie pomiędzy odbiorcą wartości lub wskaźnika
 
 Istnieją dwa powody dla których warto używać odbiorców wskaźników.
 
-Pierwszy to taki że taka metoda może zmodyfikować wartość którą wskazuje odbiorca.
+Pierwszy to taki że taka metoda może zmodyfikować wartość którą wskazuje
+odbiorca.
 
-Drugim powód jest taki, że unikamy kopiowania wartości przy każdym wywołaniu metody.
-To może być bardzo wydajna metoda pracy z danymi, jeśli na przykład odbiorca jest dużą strukturą.
+Drugim powód jest taki, że unikamy kopiowania wartości przy każdym wywołaniu
+metody. To może być bardzo wydajna metoda pracy z danymi, jeśli na przykład
+odbiorca jest dużą strukturą.
 
-W tym przykładzie, `Scale` oraz `Abs` posiadają typ odbiorcy `*Vertex`, pomimo tego że metoda `Abs` nie modyfikuje swego odbiorcy.
+W tym przykładzie, `Scale` oraz `Abs` posiadają typ odbiorcy `*Vertex`,
+pomimo tego że metoda `Abs` nie modyfikuje swego odbiorcy.
 
-W ogólny przypadku wszystkie metody danego typu powinny mieć odbiorcę wartości albo
-odbiorcę wskaźnika, ale nie mieszaninę tych dwóch.
-(Dlaczego tak jest, zobaczymy na następnych stronach.)
+W ogólny przypadku wszystkie metody zdefiniowane dla danego typu powinny
+mieć odbiorcę wartości albo odbiorcę wskaźnika, ale nie oba rodzaje
+odbiorcy na raz. (Dlaczego tak jest, zobaczymy na następnych stronach.)
 
 .play methods/methods-with-pointer-receivers.go
 
@@ -140,32 +153,39 @@ odbiorcę wskaźnika, ale nie mieszaninę tych dwóch.
 
 Typ klasy interfejs jest definiowany przez zbiór sygnatur jego metody.
 
-Wartość o typie będącym konkretnym interfejsem może przechowywać jakąkolwiek wartość która implementuje te metody.
+Wartość o typie będącym konkretnym interfejsem może przechowywać
+jakąkolwiek wartość która implementuje te metody.
 
 *Uwaga:* W przykładowym kodzie jest błąd w linii 22.
-`Vertex` (typ wartości) nie implementuje `Abser`, ponieważ
-metoda `Abs` jest zdefiniowana tylko na `*Vertex` (jet to typ wskaźnika).
+`Vertex` (typ wartości) nie implementuje `Abser`, ponieważ metoda `Abs`
+jest zdefiniowana tylko na `*Vertex` (jest to typ wskaźnik na `Vertex`).
 
 .play methods/interfaces.go
 
 * Interfejsy są implementowane domyślnie
 
 Typ implementuje interfejs implementując jego metody.
-Nie ma tutaj jawnej deklaracji tworzącej interfejs, takiej jak na przykład „implements”.
+Nie ma tutaj jawnej deklaracji tworzącej dany typ klasy interfejs, takiej
+jak na przykład „implements”.
 
-Domyślne tworzenie interfejsu rozdziela definicje interfejsu od jego implementacji, które mogą się potem pojawić w dowolnym pakiecie bez potrzeby odpowiedniej organizacji kodu.
+Domyślne tworzenie interfejsu rozdziela definicje interfejsu od jego
+implementacji, które mogą się potem pojawić w dowolnym pakiecie bez
+potrzeby wstępnej organizacji kodu.
 
 .play methods/interfaces-are-satisfied-implicitly.go
 
 * Wartości interfejsów
 
-Jeśli chodzi o szczegóły techniczne, o wartościach przyjmowanej przez interfejs można myśleć jak o krotce (ang. tuple) zawierającej wartość i konkretny typ:
+Jeśli chodzi o szczegóły techniczne, o wartościach przyjmowanej przez
+interfejs można myśleć jak o krotce (ang. tuple) zawierającej wartość
+i konkretny typ:
 
 	(wartość, typ)
 
 Wartość interfejsu przechowuje wartość posiadającą określony konkretny typ.
 
-Wywołanie metody na wartości interfejsu, wykonuje metodę o tej samej nazwie zdefiniowaną dla typu jaki ma dana wartość.
+Wywołanie metody na wartości interfejsu, wykonuje metodę o tej samej nazwie
+zdefiniowaną dla typu zawartego w interfejsie.
 
 .play methods/interface-values.go
 
@@ -175,18 +195,22 @@ Jeśli konkretna wartość w interfejsie to `nil`,
 metoda zostanie wywołana z odbiorcą `nil`.
 
 W niektórych językach wywołałoby to `null pointer exception`,
-lecz w Go często tworzymy metody, które skutecznie radzą sobie
-gdy są wywołane z odbiorcą `nil` (jako przykład można podać metodę `M` w kodzie obok).
+lecz w Go często tworzymy metody, które skutecznie radzą sobie z sytuacją
+gdy są wywołane z odbiorcą `nil` (jako przykład można podać metodę `M`
+w kodzie obok).
 
-Zauważ, że interfejs który przechowuje jako wartość `nil`, sam nie jest reprezentowany przez `nil`.
+Zauważ, że interfejs który przechowuje jako wartość `nil`, sam nie jest
+reprezentowany przez `nil`.
 
 .play methods/interface-values-with-nil.go
 
 * Wartości `nil` interfejsów
 
-Wartość `nil` interfejsu nie przetrzymuje ani konkretnej wartości ani żadnego konkretnego typu.
+Wartość `nil` interfejsu nie przetrzymuje ani konkretnej wartości ani
+żadnego konkretnego typu.
 
-Wezwanie metody na wartości interfejsu będącą `nil` powoduje błąd w czasie wykonania programu (ang. run-time error), ponieważ wewnątrz
+Wezwanie metody na wartości interfejsu będącą `nil` powoduje błąd w czasie
+wykonania programu (ang. run-time error), ponieważ wewnątrz
 interfejsu nie ma typu który wskazałby którą dokładnie metodę należy wywołać.
 
 .play methods/nil-interface-values.go
@@ -200,43 +224,53 @@ interfejsu nie ma typu który wskazałby którą dokładnie metodę należy wywo
 Pusty interfejs może przetrzymywać wartości każdego typu.
 (Każdy typ implementuje co najmniej zero metod.)
 
-Puste interfejsy używane są przez kod który obsługuje wartości nieznanych typów.
-Na przykład, `fmt.Print` przyjmuje jakakolwiek liczbę argumentów typu `interface{}`.
+Puste interfejsy używane są przez kod który obsługuje wartości nieznanych
+typów. Na przykład, `fmt.Print` przyjmuje jakakolwiek liczbę argumentów
+typu `interface{}`.
 
 .play methods/empty-interface.go
 
-* Sprawdzanie typów
+* Sprawdzanie typów (ang. type assertions)
 
-Sprawdzanie typu pozwala uzyskać dostęp do konkretnej wartości przechowywanej przez interfejs.
+Sprawdzanie typu pozwala uzyskać dostęp do wartości o konkretnym typie
+która jest zawarta w interfejsie.
 
 	t := i.(T)
 
-Instrukcja powyżej zakłada że wartość interfejsu `i` przechowuje konkretny typ `T`
-oraz przypisuje konkretną wartość interfejsu o typie `T` zmiennej `t`.
+Instrukcja powyżej zakłada że wartość interfejsu `i` zawiera konkretny
+typ `T` oraz przypisuje konkretną wartość interfejsu o typie `T` zmiennej
+`t`.
 
-Jeśli `i` nie przechowuje typu `T`, instrukcja spowoduje wywołanie paniki (ang. panic).
+Jeśli `i` nie zawiera typu `T`, instrukcja ta spowoduje wywołanie paniki
+(ang. panic).
 
-By _przetestować_ czy interfejs przechowuje wartość konkretnego typu,
-sprawdzenie typu może zwrócić dwie wartości: wartość zawartą w interfejsie oraz wartość typu bool która określa czy sprawdzenie typu dało wynik pozytywny.
+By _przetestować_ czy interfejs zawiera wartość konkretnego typu,
+sprawdzenie typu może zwrócić dwie wartości: wartość zawartą w interfejsie
+oraz wartość typu bool która określa czy sprawdzenie typu dało wynik
+pozytywny.
 
 	t, ok := i.(T)
 
-Jeśli `i` zawiera typ `T`, wtedy `t` będzie wartością zawartą w interfejsie a `ok` będzie miało wartość `true`.
+Jeśli `i` zawiera typ `T`, wtedy `t` będzie wartością zawartą w interfejsie
+a `ok` będzie miało wartość `true`.
 
-W przeciwnym wypadku, `ok` będzie miało wartość `false`, a `t` będzie miało wartością zerową typu `T`, zaś panika (ang. panic) nie zostanie wywołana.
+W przeciwnym wypadku, `ok` będzie miało wartość `false`, a `t` będzie miało
+wartością zerową typu `T`, zaś panika (ang. panic) nie zostanie wywołana.
 
 
-Zauważ podobieństwo między składnią powyżej i tą która jest używana by odczytać wartość z mapy.
+Zauważ podobieństwo między składnią powyżej i tą która jest używana by
+odczytać wartość z mapy.
 
 .play methods/type-assertions.go
 
 * Instrukcja switch typów (ang. switch)
 
-Switch typów jest konstrukcją który pozwala dokonać kilku sprawdzeń typów po kolei.
+Switch typów jest konstrukcją który pozwala dokonać kilku sprawdzeń typów
+po kolei.
 
-Switch typów jest normalna instrukcja switch, jednak warunki w switch typów
-określają odpowiednie typy,  a nie wartości. Wartości tych typów porównywane są z typem
-wartości zawartej w konkretnej wartości interfejsu.
+Switch typów jest jak normalna instrukcja switch, jednak warunki w switch
+typów określają odpowiednie typy, a nie wartości. Wartości tych typów
+porównywane są z typem wartości zawartej w wartości interfejsu.
 
 	switch v := i.(type) {
 	case T:
@@ -250,30 +284,33 @@ wartości zawartej w konkretnej wartości interfejsu.
 Deklaracja w switch typów ma tą samą składnię co sprawdzenie typu `i.(T)`,
 jednak konkretny typ `T` jest zastąpiony słowem kluczowym `type`.
 
-Ta instrukcja switch sprawdza czy wartość interfejsu `i`
-zawiera wartość typu `T` lub `S`.
-W przypadku warunków na `T` lub `S`, zmienna `v` przyjmie typ
-`T` lub `S` i przyjmie wartość zawartą w `i`.
-W przypadku warunku domyślnego (ang. default), zmienna `v` przyjmie ten sam typ interfejs oraz tą samą wartość co `i`.
+Ta instrukcja switch sprawdza czy wartość interfejsu `i` zawiera wartość
+typu `T` lub `S`. W przypadku warunków na `T` lub `S`, zmienna `v` przyjmie
+typ `T` lub `S` i przyjmie wartość zawartą w `i`. W przypadku warunku
+domyślnego (ang. default), zmienna `v` przyjmie ten sam typ klasy interfejs
+oraz tą samą wartość co `i`.
 
 .play methods/type-switches.go
 
 * Stringers
 
-Jednym z najbardziej wszechobecnym interfejsów jest [[//golang.org/pkg/fmt/#Stringer][`Stringer`]] zdefiniowany przez pakiet [[//golang.org/pkg/fmt/][`fmt`]].
+Jednym z najbardziej wszechobecnym interfejsów jest
+[[//golang.org/pkg/fmt/#Stringer][`Stringer`]] zdefiniowany przez pakiet
+[[//golang.org/pkg/fmt/][`fmt`]].
 
 	type Stringer interface {
 		String() string
 	}
 
-`Stringer` jest typem który może przedstawić samego siebie jako string. Pakiet `fmt`
-(i wiele innych) używa tego interfejsu by wypisywac wartości.
+`Stringer` jest typem który może przedstawić samego siebie jako string.
+Pakiet `fmt` (i wiele innych) używa tego interfejsu by wypisywać wartości.
 
 .play methods/stringer.go
 
 * Ćwiczenie: Stringers
 
-Spraw by typ `IPAddr` zaimplementował `fmt.Stringer` poprzez metodę wypisując adres jako cztery liczby obdzielone kropkami.
+Spraw by typ `IPAddr` zaimplementował `fmt.Stringer` poprzez metodę
+wypisującą adres jako cztery liczby obdzielone kropkami.
 
 Na przykład, `IPAddr{1,`2,`3,`4}` powinien zostać wypisany jako `"1.2.3.4"`.
 
@@ -289,7 +326,8 @@ Typ `error` jest wbudowanym interfejsem podobnym do `fmt.Stringer`:
 		Error() string
 	}
 
-(Tak samo jak w przypadku `fmt.Stringer`, pakiet `fmt` szuka interfejsu `error` gdy wypisuje wartości.)
+(Tak samo jak w przypadku `fmt.Stringer`, pakiet `fmt` szuka interfejsu
+`error` gdy wypisuje wartości.)
 
 Funkcje często zwracają wartość `error`, a kod wywołujący funkcję powinien
 obsłużyć błąd, testując czy `error` jest równy `nil`.
@@ -301,15 +339,19 @@ obsłużyć błąd, testując czy `error` jest równy `nil`.
 	}
 	fmt.Println("Converted integer:", i)
 
-`error` o wartości `nil` oznacza sukces; `error` o wartości innej niż `nil` oznacza porażkę.
+`error` o wartości `nil` oznacza sukces; `error` o wartości innej niż `nil`
+oznacza porażkę.
 
 .play methods/errors.go
 
 * Ćwiecznie: Errors
 
-Skopiuj swoją funkcję `Sqrt` z [[/flowcontrol/8][wcześniejszego ćwiczenia]] i zmodyfikuj ją tak by zwracała również wartość typu `error`.
+Skopiuj swoją funkcję `Sqrt` z [[/flowcontrol/8][wcześniejszego ćwiczenia]]
+i zmodyfikuj ją tak by zwracała również wartość typu `error`.
 
-`Sqrt` powinna zwrócić wartość `error` inną niż `nil`, kiedy jej argument liczbowy będzie liczbą ujemną, gdyż funkcja ta nie pracuje z liczbami zespolonymi.
+`Sqrt` powinna zwrócić wartość `error` inną niż `nil`, kiedy jej argument
+liczbowy będzie liczbą ujemną, gdyż funkcja ta nie pracuje z liczbami
+zespolonymi.
 
 Stwórz nowy typ
 
@@ -319,26 +361,36 @@ i spraw by był on interfejsem typu `error` poprzez implementację metody
 
 	func (e ErrNegativeSqrt) Error() string
 
-Jako rezultat wywołania `ErrNegativeSqrt(-2).Error()` powinien zostać zwrócony string `"cannot`Sqrt`negative`number:`-2"`.
+Jako rezultat wywołania `ErrNegativeSqrt(-2).Error()` powinien zostać
+zwrócony string `"cannot`Sqrt`negative`number:`-2"`.
 
-*Uwaga:* Wywołanie `fmt.Sprint(e)` wewnątrz metody `Error` spowoduje że program wejdzie w nieskończoną pętle. Możesz tego uniknąć po dokonując konwersji `e`: `fmt.Sprint(float64(e))`. Spróbuj odpowiedzieć sobie, dlaczeo tak jest?
+*Uwaga:* Wywołanie `fmt.Sprint(e)` wewnątrz metody `Error` spowoduje że
+program wejdzie w nieskończoną pętle. Możesz tego uniknąć po dokonując
+konwersji `e`: `fmt.Sprint(float64(e))`. Spróbuj odpowiedzieć sobie,
+dlaczego tak jest?
 
-Zmień swoją funkcję `Sqrt` tak by zwracała wartość typu `ErrNegativeSqrt` gdy otrzyma jako argument liczbę ujemną.
+Zmień swoją funkcję `Sqrt` tak by zwracała wartość typu `ErrNegativeSqrt`
+gdy otrzyma jako argument liczbę ujemną.
 
 .play methods/exercise-errors.go
 
 * Czytniki (ang. readers)
 
-Pakiet `io` definiuje interfejs `io.Reader`,
-który pozwala czytać ze strumienia danych.
+Pakiet `io` definiuje interfejs `io.Reader`, który pozwala czytać ze
+strumienia danych.
 
-Standardowa biblioteka Go zawiera [[https://golang.org/search?q=Read#Global][wiele implementacji]] tego interfejsu, między innymi dla plików, połączenia sieciowych, kompresorów danych, szyfrów i innych.
+Standardowa biblioteka Go zawiera
+[[https://golang.org/search?q=Read#Global][wiele implementacji]] tego
+interfejsu, między innymi dla plików, połączenia sieciowych, kompresorów
+danych, szyfrów i innych.
 
 `io.Reader` interfejs posiada metodę `Read`:
 	func (T) Read(b []byte) (n int, err error)
 
-`Read` zapełnia wycinek wskazujący tablicę bajtów odczytanymi danymi, zwraca zas inta reprezentującego ilość przeczytanych bajtów właśnie wycinek bitów oraz wartość typu `error`. Gdy `Read` dojdzie do końca strumienia danych
-błąd `io.EOF` (błąd końca pliku, ang. end of file error).
+`Read` zapełnia odczytanymi danymi wycinek wskazujący na tablicę bajtów,
+zwraca zaś inta reprezentującego ilość przeczytanych bajtów właśnie
+oraz wartość typu `error`. Gdy `Read` dojdzie do końca strumienia danych
+zwraca błąd `io.EOF` (błąd końca pliku, ang. end of file error).
 
 Kod podany w przykładzie tworzy
 [[//golang.org/pkg/strings/#Reader][`strings.Reader`]]
@@ -348,27 +400,38 @@ oraz pobiera 8 bajtów ze strumienia przy każdym wywołaniu.
 
 * Ćwiczenie: Readers
 
-Zaimplementuj typ `Reader` który wysyła nieskończony łańcuch znaku ASCII
-`'A'`.
+Zaimplementuj typ `Reader` który wysyła nieskończony strumień zawierający
+tylko znak ASCII `'A'`.
 
 .play methods/exercise-reader.go
 
 * Ćwiczenie: rot13Reader
 
-Często spotykanym schematem postępowania jest tworzenie interfejsu typu [[https://golang.org/pkg/io/#Reader][io.Reader]] wewnątrz którego znajduje się kolejny `io.Reader`, przy czym zewnętrzy interfejs posiada inne metody obsługujące strumień danych.
+Często spotykanym schematem postępowania jest tworzenie interfejsu typu
+[[https://golang.org/pkg/io/#Reader][io.Reader]] wewnątrz którego znajduje
+się kolejny `io.Reader`, przy czym zewnętrzy interfejs posiada inne metody
+obsługujące strumień danych.
 
-Na przykład, funkcja [[https://golang.org/pkg/compress/gzip/#NewReader][gzip.NewReader]] bierze `io.Reader` (strumień skompresowanych danych) i zwraca `*gzip.Reader` który również implementuje `io.Reader` (strumień nieskompresowanych danych).
+Na przykład, funkcja
+[[https://golang.org/pkg/compress/gzip/#NewReader][gzip.NewReader]] bierze
+`io.Reader` (strumień skompresowanych danych) i zwraca `*gzip.Reader` który
+również implementuje `io.Reader` (strumień zdekompresowanych danych).
 
-Zaimplementuj `rot13Reader` który implementuje `io.Reader` oraz czyta z tego `io.Reader`, modyfikując otrzymany strumień po przez użycie szyfru podstawieniowego [[https://en.wikipedia.org/wiki/ROT13][rot13]] do wszystkich liter alfabetu.
+Zaimplementuj `rot13Reader` który implementuje `io.Reader` oraz czyta z tego
+`io.Reader`, modyfikując otrzymany strumień po przez użycie szyfru
+podstawieniowego [[https://en.wikipedia.org/wiki/ROT13][rot13]]
+do wszystkich liter alfabetu.
 
 Typ `rot13Reader` jest już dla ciebie zdefiniowany.
-Zrób z niego interfejs typu `io.Reader` po przez zaimplementowanie dla niego metody `Read`.
+Zrób z niego interfejs typu `io.Reader` po przez zaimplementowanie dla niego
+metody `Read`.
 
 .play methods/exercise-rot-reader.go
 
 * Obrazy (ang. images)
 
-[[https://golang.org/pkg/image/#Image][Pakiet `image`]] definiuje interfejs `Image`:
+[[https://golang.org/pkg/image/#Image][Pakiet `image`]] definiuje interfejs
+`Image`:
 
 	package image
 
@@ -378,27 +441,39 @@ Zrób z niego interfejs typu `io.Reader` po przez zaimplementowanie dla niego me
 		At(x, y int) color.Color
 	}
 
-*Uwaga*: Dokładniej rzecz biorąc typ wartości zwracanej przez metodę `Bounds` to nie `Rectangle`, lecz
+*Uwaga*: Dokładniej rzecz biorąc typ wartości zwracanej przez metodę
+`Bounds` to nie `Rectangle`, lecz
 [[https://golang.org/pkg/image/#Rectangle][`image.Rectangle`]], ponieważ
 jego deklaracja znajduje się w pakiecie `image`.
 
-(Zobacz odpowiedni [[https://golang.org/pkg/image/#Image][fragment dokumentacji]] by dowiedzieć się więcej.)
+(Zobacz odpowiedni
+[[https://golang.org/pkg/image/#Image][fragment dokumentacji]] by dowiedzieć
+się więcej.)
 
-Typy `color.Color` oraz `color.Model` również są interfejsami, jednak zignorujemy ten fakt poprzez użycie zdefiniowanych wcześniej implementacji `color.RGBA` oraz `color.RGBAModel`. Te interfejsy oraz typy dany są zdefiniowane w pakiecie [[https://golang.org/pkg/image/color/][image/color]].
+Typy `color.Color` oraz `color.Model` również są interfejsami, jednak
+zignorujemy ten fakt poprzez użycie zdefiniowanych wcześniej implementacji
+`color.RGBA` oraz `color.RGBAModel`. Te interfejsy oraz typy dany są
+zdefiniowane w pakiecie [[https://golang.org/pkg/image/color/][image/color]].
 
 .play methods/images.go
 
 * Ćwiczenie: Images
 
-Pamiętasz [[/moretypes/18][generator obrazów]] który napisałeś wcześniej? Spróbujmy napisać kolejny, tym razem zamiast zwracać wycinek danych, zwróci on implementację interfejsu `image.Image`.
+Pamiętasz [[/moretypes/18][generator obrazów]] który napisałeś wcześniej?
+Spróbujmy napisać kolejny, tym razem zamiast zwracać wycinek danych, zwróci
+on implementację interfejsu `image.Image`.
 
-Zdefiniuj swój własny typ `Image`, zaimplementuj [[https://golang.org/pkg/image/#Image][wymagane metody]], oraz wywołaj `pic.ShowImage`.
+Zdefiniuj swój własny typ `Image`, zaimplementuj
+[[https://golang.org/pkg/image/#Image][wymagane metody]], oraz wywołaj
+`pic.ShowImage`.
 
-Metoda `Bounds` powinna zwrócić wartość typu `image.Rectangle`, przykładowo `image.Rect(0,`0,`w,`h)`.
+Metoda `Bounds` powinna zwrócić wartość typu `image.Rectangle`, przykładowo
+`image.Rect(0,`0,`w,`h)`.
 
 Metoda `ColorModel` powinna zwrócić `color.RGBAModel`.
 
-Metoda `At` powinna zwrócić kolor; wartości `v` w poprzednim generatorze obrazów odpowiada teraz wartość `color.RGBA{v,`v,`255,`255}`.
+Metoda `At` powinna zwrócić kolor; wartości `v` w poprzednim generatorze
+obrazów odpowiada teraz wartość `color.RGBA{v,`v,`255,`255}`.
 
 .play methods/exercise-images.go
 
@@ -406,4 +481,6 @@ Metoda `At` powinna zwrócić kolor; wartości `v` w poprzednim generatorze obra
 
 Ukończyłeś tę lekcję!
 
-Możesz wrócić do listy [[/list][modułów]] by zobaczyć czego więcej możesz się nauczyć, lub od razu przejść do [[javascript:click('.next-page')][następnej lekcji]].
+Możesz wrócić do listy [[/list][modułów]] by zobaczyć czego więcej
+możesz się nauczyć, lub od razu przejść do
+[[javascript:click('.next-page')][następnej lekcji]].

--- a/content/methods.article
+++ b/content/methods.article
@@ -1,5 +1,5 @@
 Metody oraz interfejsy
-Ta lekcja pokrywa metody oraz interfejsy, konstrukty które definiują obiekty oraz ich zachowanie.
+Ta lekcja omawia metody oraz interfejsy, konstrukcje które definiują obiekty oraz ich zachowanie.
 
 Autorzy Go
 https://golang.org
@@ -7,59 +7,57 @@ https://golang.org
 * Metody
 
 Go nie posiada klas.
-Jednakże, możesz przypisać metody nazwanym typom.
+Jednakże, możesz definiować metody dla danych typów.
 
-Metoda to funkcja ze specjalnym argumentem _odbiornikiem_ (tzw. _receiver_)
+Metoda to funkcja ze specjalnym argumentem nazywanym __odbiorcą__ (tzw. _receiver_)
 
-Odbiornik pojawia się w swej własnej liście argumentów pomiędzy słowem `func` 
+Odbiorca pojawia się w swojej własnej liście argumentów pomiędzy słowem `func`
 a nazwą metody.
 
-W tym przykładzie, metoda `Abs` posiada odbiornik typu `Vertex` nazwanym `v`.
+W tym przykładzie, metoda `Abs` posiada odbiorcę typu `Vertex` o nazwie `v`.
 
 .play methods/methods.go
 
 * Metody to funkcje
 
-Zapamiętaj: metoda to po prostu funkcja z odbiornikiem.
+Zapamiętaj: metoda to po prostu funkcja posiadają odbiorcę jako swój argument.
 
-Oto `Abs` zapisana jako regularna funkcja bez zmian w jej funkcjonalności.
+Tutaj mamy `Abs` zdefiniowany jako normalna funkcja bez zmian w jej funkcjonalności.
 
 .play methods/methods-funcs.go
 
 * Metody ciąg dalszy
 
-Możesz równierz zadeklarować metodę na nie-konstruktowych typach.
+Możesz również zadeklarować metodę na typach nie będących strukturami.
 
-W tym przykładzie, widzimy numeryczną wartość `MyFloat` wraz z metodą `Abs`.
+W tym przykładzie, widzimy typ numeryczny `MyFloat` wraz z metodą `Abs`.
 
-Metodę, możesz tylko zadeklarować z odbiornikiem którego typ zdefiniowany jest w tym
-samym pakiecie co metoda.
-Nie możesz zadeklarować metody z odbiornikiem którego typ zadeklarowany jest w innym pakiecie
-(to równierz dotyczy wbudowanych typów, takich jak `int`).
+Metodę możesz zadeklarować tylko dla odbiorcy którego typ jest zdefiniowany w tym samym pakiecie co metoda.
+Nie możesz zadeklarować metody dla odbiorcy którego typ jest zadeklarowany w innym pakiecie
+(dotyczy to w szczególności wbudowanych typów, takich jak `int`).
 
 .play methods/methods-continued.go
 
-* Odbiorniki wskaźnikowe
+* Odbiorcy wskaźników
 
-Możesz zadeklarować metody z odbiornikami wskaźnikowymi (tzw. pointer receivers).
+Możesz zadeklarować metody dla odbiorcy wskaźnika (ang. pointer receivers).
 
-To oznacza, że typ odbiornika ma składnię literału `*T` dla jakiegoś typu `T`.
-(Równierz, `T` nie może być wskaźnikiem takim jak na przykład `*int`.)
+To oznacza, że typ odbiorncy ma składnię literalną `*T` dla jakiegoś typu `T`.
+(Dodatkowo `T` sam nie może być wskaźnikiem, takim jak przykładowo `*int`.)
 
-Na przykład, metoda `Scale` zdefiniowana jest na `*Vertex`.
+Na przykład, metoda `Scale` zdefiniowana jest dla typu `*Vertex`.
 
-Metody z odbiornikami wskaźnikowymi mogą zmieniać wartości które wskazuje odbiornik
+Metody z odbiorcami wskaźników mogą zmieniać wartości które wskazuje odbiorca
 (tak jak `Scale` robi to w tym przykładzie).
-Ponieważ metody często muszą zmieniać odbiornik, odbiorniki wskaźnikowe są dużo 
-częsciej używane niżeli odbiorniki wartości.
+Ponieważ metody często potrzebują zmieniać swojego odbiorcę, odbiorcy wskaźników są dużo
+częściej używani niż odbiorcy wartości.
 
-Spróbuj usunąć `*` z deklaracji funkcji `Scale` na lini 16 i zobacz jak zmieni się
+Spróbuj usunąć `*` z deklaracji funkcji `Scale` w linii 16 i zobacz jak zmieni się
 zachowanie programu.
 
-Z odbiornikiem wartości, metoda `Scale` operuje na podstawie kopii oryginalnej
-wartości `Vertex`.
-(Jest to takie samo zachowanie jak zachowanie funkcji co do każdego innego argumentu.)
-Metoda `Scale` musi posiadać odbiornik wskaźnikowy by zmienić wartość `Vertex` zadeklarowaną 
+Zdefiniowana z odbiorcą wartości, metoda `Scale` operuje na kopii wartości typu `Vertex`.
+(Jest to takie samo zachowanie jak w przypadku wszystkich innych argumentów funkcji.)
+Metoda `Scale` musi posiadać odbiorcę wskaźnika by móc zmienić wartość typu `Vertex` zadeklarowaną
 w funkcji `main`.
 
 .play methods/methods-pointers.go
@@ -68,183 +66,177 @@ w funkcji `main`.
 
 Tu widzimy metody `Abs` oraz `Scale` zapisane jako funkcje.
 
-Jeszcze raz spróbuj usunąć `*` z lini 16.
-Potrafisz dostrzec dlaczego zachowanie się zmieniło?
-Co jeszcze musiałeś zmienić by przykład się skompilowal?
+Jeszcze raz spróbuj usunąć `*` z linii 16.
+Czy potrafisz dostrzec dlaczego zachowanie programu się zmieniło?
+Co jeszcze powinieneś zmienić by przykład się skompilował?
 
-(Jeśli nie jesteś pewien, kontynuuj do następnej strony.)
+(Jeśli nie jesteś pewien, przejdź do następnej strony.)
 
 .play methods/methods-pointers-explained.go
 
-* Metody oraz wskaźnik pośredni
+* Metody oraz dereferencja wskaźników
 
-Porównując dwa poprzednie programy, mogłeś zauważyć że 
-funkcje z argumentem wskaźnikowym muszą przyjmować wskaźnik:
+Porównując dwa poprzednie programy, mogłeś zauważyć że
+funkcje z argumentem będący wskaźnikiem mogą przyjmować tylko wskaźnik:
 
 	var v Vertex
 	ScaleFunc(v, 5)  // Compile error!
 	ScaleFunc(&v, 5) // OK
 
-podczas gdy metody z odbiornikami wskaźnikowymi przyjmują wartość lub wskaźnik jako
-odbiornik gdy są wywołane:
+podczas gdy metody z odbiornikiem wskaźnika przyjmują zarówno wartość jaki i wskaźnik jako
+swojego odbiorcą gdy są wywoływane:
 
 	var v Vertex
 	v.Scale(5)  // OK
 	p := &v
 	p.Scale(10) // OK
 
-Dla wyrażenia `v.Scale(5)`, nawet jeśli `v` jest wartością a nie wskaźnikiem,
-metoda z wskaźnikiem odbiornika jest wywołana automatycznie.
-To znaczy, dla wygody, Go iterpretuje wyrażenie `v.Scale(5)` jako
-`(&v).Scale(5)` ponieważ metoda `Scale` posiada wskaźnik odbiornika.
+W instrukcji `v.Scale(5)`, nawet jeśli `v` jest wartością a nie wskaźnikiem,
+metoda z odbiorcą wskaźnika jest wywołana automatycznie.
+Dzieje się tak, ponieważ dla wygody programowania Go interpretuje instrukcję `v.Scale(5)` jako
+`(&v).Scale(5)`, gdyż metoda `Scale` posiada odbiorcę wskaźnika.
 
 .play methods/indirection.go
 
-* Metody oraz wskaźnik pośredni (2)
+* Metody oraz dereferencja wskaźników (2)
 
-To samo dzieje się w drugim kierunku.
+To samo dzieje się w odwrotnej sytuacji.
 
-Funkcje które przyjmują argument wartości muszą przyjąć wartość danego typu:
+Funkcje które przyjmują jako argument wartość, mogą być wywołane tylko z wartością danego typu:
 
 	var v Vertex
 	fmt.Println(AbsFunc(v))  // OK
 	fmt.Println(AbsFunc(&v)) // Compile error!
 
-podczas gdy metody z odbiornikami wartości przyjmują wartość lub wskaźnik jako 
-odbiornik gdy są wywołane:
+podczas gdy metody z odbiorcą wartości przyjmują zarówno wartość jaki i wskaźniki jako swojego odbiorcę, gdy są wywołane w następujący sposób:
 
 	var v Vertex
 	fmt.Println(v.Abs()) // OK
 	p := &v
 	fmt.Println(p.Abs()) // OK
 
-W tym przypadku, wywołanie metody `p.Abs()` jest interpretowane jako `(*p).Abs()`.
+W takiej sytuacji, wywołanie metody `p.Abs()` jest interpretowane jako `(*p).Abs()`.
 
 .play methods/indirection-values.go
 
-* Wybranie wartości jako wskaźnik odbiornika. 
+* Wybranie pomiędzy odbiorcą wartości lub wskaźnika
 
-Istnieją dwa powody dla których warto używać wskaźnik odbiornika.
+Istnieją dwa powody dla których warto używać odbiorców wskaźników.
 
-Pierwszy to taki że metoda może zmodyfikować wartość którą wskazuje odbiornik.
+Pierwszy to taki że taka metoda może zmodyfikować wartość którą wskazuje odbiorca.
 
-Drugim powodem jest unikanie kopiowania wartości przy każdym wywołaniu metody.
-Jest to szczególnie wydajne gdy na przykład odbiornik jest dużą strukturą.
+Drugim powód jest taki, że unikamy kopiowania wartości przy każdym wywołaniu metody.
+To może być bardzo wydajna metoda pracy z danymi, jeśli na przykład odbiorca jest dużą strukturą.
 
-W tym przykładzie, `Scale` oraz `Abs` posiadają tryb odbiornika, `*Vertex`,
-nawet pomimo tego że metoda `Abs` nie modyfikuje swego odbiornika.
+W tym przykładzie, `Scale` oraz `Abs` posiadają typ odbiorcy `*Vertex`, pomimo tego że metoda `Abs` nie modyfikuje swego odbiorcy.
 
-Generalnie, wszystkie metody danego typu powinny mieć odbiornik wartości lub 
-wskaźnik odbiornika, lecz nie mieszanine obu.
-(Zobaczymy dlaczego na następnych stronach)
+W ogólny przypadku wszystkie metody danego typu powinny mieć odbiorcę wartości albo
+odbiorcę wskaźnika, ale nie mieszaninę tych dwóch.
+(Dlaczego tak jest, zobaczymy na następnych stronach.)
 
 .play methods/methods-with-pointer-receivers.go
 
-* Interfejsy (tzw. interfaces)
+* Interfejsy (ang. interfaces)
 
-Typ interfejsu jest definiowany jako zestaw sygnatur metody.
+Typ klasy interfejs jest definiowany przez zbiór sygnatur jego metody.
 
-Wartość typu interfejsu może przetrzymywać jakąkolwiek wartość która implementuje te metody.
+Wartość o typie będącym konkretnym interfejsem może przechowywać jakąkolwiek wartość która implementuje te metody.
 
-*Uwaga:* W przykładowym kodzie jest błąd na lini 22.
-`Vertex` (wartość typu) nie implementuje `Abser` ponieważ
-metoda `Abs` jest zdefiniowana tylko na `*Vertex` (typ wskaźnika).
+*Uwaga:* W przykładowym kodzie jest błąd w linii 22.
+`Vertex` (typ wartości) nie implementuje `Abser`, ponieważ
+metoda `Abs` jest zdefiniowana tylko na `*Vertex` (jet to typ wskaźnika).
 
 .play methods/interfaces.go
 
-* Interfejsy są implementowane niejawnie
+* Interfejsy są implementowane domyślnie
 
-Typ implementuje interfejs implementujac jego metody.
-Nie ma tutaj wyraźnej deklaracji intencji, takiej jak na przykład "implements".
+Typ implementuje interfejs implementując jego metody.
+Nie ma tutaj jawnej deklaracji tworzącej interfejs, takiej jak na przykład „implements”.
 
-Niejawne interfejsy rozdzielają definicje interfejsu od jego implementacji,
-co sprawia, że poźniej mogą pojawić się w danym pakiecie bez wcześniejszego uzgodnienia.
+Domyślne tworzenie interfejsu rozdziela definicje interfejsu od jego implementacji, które mogą się potem pojawić w dowolnym pakiecie bez potrzeby odpowiedniej organizacji kodu.
 
 .play methods/interfaces-are-satisfied-implicitly.go
 
 * Wartości interfejsów
 
-O wartościach interfejsów można by pomyśleć jak o parze uporządkowanych zbiorów (tzw. tuple) które 
-składają się z wartości i konkretnego typu:
+Jeśli chodzi o szczegóły techniczne, o wartościach przyjmowanej przez interfejs można myśleć jak o krotce (ang. tuple) zawierającej wartość i konkretny typ:
 
 	(wartość, typ)
 
-Wartość interfejsu przetrzymuje wartość określonego rodzaju typu.
+Wartość interfejsu przechowuje wartość posiadającą określony konkretny typ.
 
-Wezwanie metody na wartości interfejsu, egzekwuje metode o tej samej nazwie na jej
-określonym typie.
+Wywołanie metody na wartości interfejsu, wykonuje metodę o tej samej nazwie zdefiniowaną dla typu jaki ma dana wartość.
 
 .play methods/interface-values.go
 
-* Wartości interfejsu z brakiem wartości (nil)
+* Wartości interfejsu przechowujące wartość `nil`
 
-Jeśli konkretna wartość w interfejsie posiada brak wartości,
-metoda zostanie wywołana z odbiornikiem bez wartości. 
+Jeśli konkretna wartość w interfejsie to `nil`,
+metoda zostanie wywołana z odbiorcą `nil`.
 
-W niektórych językach to wywołałoby `null pointer exception`,
-lecz w Go, często pisze się metody, które skutecznie radzą sobie 
-gdy są wywołane z odbiornikiem bez wartości (tak jak można zobaczyć w przykładzie obok, metodzie `M`).
+W niektórych językach wywołałoby to `null pointer exception`,
+lecz w Go często tworzymy metody, które skutecznie radzą sobie
+gdy są wywołane z odbiorcą `nil` (jako przykład można podać metodę `M` w kodzie obok).
 
-Zauważ, że interfejs który przetrzymuje wartość zawierającą nil, sam w sobie nie jest bez wartości.
+Zauważ, że interfejs który przechowuje jako wartość `nil`, sam nie jest reprezentowany przez `nil`.
 
 .play methods/interface-values-with-nil.go
 
-* Nilowe wartości intefejsów
+* Wartości `nil` interfejsów
 
-Wartość nilowa interfejsu nie przetrzymuje ani wartości ani żadnego konkretnego typu.
+Wartość `nil` interfejsu nie przetrzymuje ani konkretnej wartości ani żadnego konkretnego typu.
 
-Wezwanie metody na nilowym interfejsie powoduje błąd, ponieważ wewnątrz
-interfejsu nie ma typu który wskazałby którą dokładnie metode wywołać.
+Wezwanie metody na wartości interfejsu będącą `nil` powoduje błąd w czasie wykonania programu (ang. run-time error), ponieważ wewnątrz
+interfejsu nie ma typu który wskazałby którą dokładnie metodę należy wywołać.
 
 .play methods/nil-interface-values.go
 
-* Pusty intefejs
+* Pusty interfejs
 
-Interfejs który nie określa żadnej metody, nazwany jest pustym interfejsem:
+„Pusty interfejs” to typ interfejs który nie określa żadnej metody:
 
 	interface{}
 
 Pusty interfejs może przetrzymywać wartości każdego typu.
-(Każd typ implementuje co najmniej zero metod)
+(Każdy typ implementuje co najmniej zero metod.)
 
 Puste interfejsy używane są przez kod który obsługuje wartości nieznanych typów.
 Na przykład, `fmt.Print` przyjmuje jakakolwiek liczbę argumentów typu `interface{}`.
 
 .play methods/empty-interface.go
 
-* Asercje typów
+* Sprawdzanie typów
 
-Asercja typu dostarcza dostęp do konkretnej wartości danej wartości interfejsu.
+Sprawdzanie typu pozwala uzyskać dostęp do konkretnej wartości przechowywanej przez interfejs.
 
 	t := i.(T)
 
-Instrukcja powyżej zakłada że wartość interfejsu `i` przetrzymuje konkretny typ `T`
-oraz przypisuje zasadniczą wartość `T` zmiennej `t`.
+Instrukcja powyżej zakłada że wartość interfejsu `i` przechowuje konkretny typ `T`
+oraz przypisuje konkretną wartość interfejsu o typie `T` zmiennej `t`.
 
-Jeśli `i` nie posiada `T`, instrukcja spowoduje panikę(tzw. panic).
+Jeśli `i` nie przechowuje typu `T`, instrukcja spowoduje wywołanie paniki (ang. panic).
 
-By przetestować czy interfejs posiada wartość specyficznego typu,
-asercja typu może zwrócić dwie wartości: wartość zasadniczą oraz
-wartość boolean która określa czy dana asercja osiągnęła sukces.
+By _przetestować_ czy interfejs przechowuje wartość konkretnego typu,
+sprawdzenie typu może zwrócić dwie wartości: wartość zawartą w interfejsie oraz wartość typu bool która określa czy sprawdzenie typu dało wynik pozytywny.
 
 	t, ok := i.(T)
 
-Jeśli `i` posiada `T`, wtedy `t` będzie wartością zasadniczą a `ok` będzie prawdą (true).
+Jeśli `i` zawiera typ `T`, wtedy `t` będzie wartością zawartą w interfejsie a `ok` będzie miało wartość `true`.
 
-Jeśli jednak nie, `ok` będzie fałszem (false) a `t` będzie wartością zerową typu `T`,
-i nie będzie paniki.
+W przeciwnym wypadku, `ok` będzie miało wartość `false`, a `t` będzie miało wartością zerową typu `T`, zaś panika (ang. panic) nie zostanie wywołana.
 
-Zauważ podobieństwo między składnią powyżej jak tą która używana jest by czytać mapy.
+
+Zauważ podobieństwo między składnią powyżej i tą która jest używana by odczytać wartość z mapy.
 
 .play methods/type-assertions.go
 
-* Typ warunku wielokrotnego wyboru (tzw. switch)
+* Instrukcja switch typów (ang. switch)
 
-Switch jest konstruktem który pozwala na wiele asercji typów w serii.
+Switch typów jest konstrukcją który pozwala dokonać kilku sprawdzeń typów po kolei.
 
-Typ switch jest jak regularna instrukcja switch, jednak cases w typie switch
-specyfikują typy, nie wartości, wartości tych typów porównywane są z typami
-wartości przetrzymywanymi w danych wartościach interfejsu.
+Switch typów jest normalna instrukcja switch, jednak warunki w switch typów
+określają odpowiednie typy,  a nie wartości. Wartości tych typów porównywane są z typem
+wartości zawartej w konkretnej wartości interfejsu.
 
 	switch v := i.(type) {
 	case T:
@@ -252,18 +244,17 @@ wartości przetrzymywanymi w danych wartościach interfejsu.
 	case S:
 		// v ma typ S
 	default:
-		// brak zgody; v ma ten sam typ co i
+		// żaden warunek nie pasuje; v ma ten sam typ co i
 	}
 
-Deklaracja w typie switch ma tą samą składnię co typ asercji `i.(T)`,
-jednak specyficzny typ `T` jest zamieniony ze słowem kluczem `type`.
+Deklaracja w switch typów ma tą samą składnię co sprawdzenie typu `i.(T)`,
+jednak konkretny typ `T` jest zastąpiony słowem kluczowym `type`.
 
-Ta instrukcja switch sprawdza czy wartość interfesju `i`
-przetrzymuje wartość typu `T` lub `S`.
-W każdym `T` oraz `S`, zmienna `v` będzie typu 
-`T` lub `S` i przetrzyma wartość posiadaną przez `i`.
-W default case, zmienna `v` jest tego samego typu oraz wartości co
-wartość `i`.
+Ta instrukcja switch sprawdza czy wartość interfejsu `i`
+zawiera wartość typu `T` lub `S`.
+W przypadku warunków na `T` lub `S`, zmienna `v` przyjmie typ
+`T` lub `S` i przyjmie wartość zawartą w `i`.
+W przypadku warunku domyślnego (ang. default), zmienna `v` przyjmie ten sam typ interfejs oraz tą samą wartość co `i`.
 
 .play methods/type-switches.go
 
@@ -275,22 +266,22 @@ Jednym z najbardziej wszechobecnym interfejsów jest [[//golang.org/pkg/fmt/#Str
 		String() string
 	}
 
-`Stringer` jest typem który może przedstawić się jako string. Pakiet `fmt`
-(i wiele innych) potrzebuje tego pakietu by wydrukować wartości.
+`Stringer` jest typem który może przedstawić samego siebie jako string. Pakiet `fmt`
+(i wiele innych) używa tego interfejsu by wypisywac wartości.
 
 .play methods/stringer.go
 
 * Ćwiczenie: Stringers
 
-Spraw by typ `IPAddr` implementował `fmt.Stringer` by wydrukować 4 ciągi liczb z kropkami.
+Spraw by typ `IPAddr` zaimplementował `fmt.Stringer` poprzez metodę wypisując adres jako cztery liczby obdzielone kropkami.
 
-Na przykład, `IPAddr{1,`2,`3,`4}` powinien się wydrukować jako `"1.2.3.4"`.
+Na przykład, `IPAddr{1,`2,`3,`4}` powinien zostać wypisany jako `"1.2.3.4"`.
 
 .play methods/exercise-stringer.go
 
-* Błędy (tzw. errors)
+* Błędy (ang. errors)
 
-Programy Go wyrażają błedy poprzez wartości `error`.
+Błędy w Go to wartości typu `error`.
 
 Typ `error` jest wbudowanym interfejsem podobnym do `fmt.Stringer`:
 
@@ -298,10 +289,10 @@ Typ `error` jest wbudowanym interfejsem podobnym do `fmt.Stringer`:
 		Error() string
 	}
 
-(Tak samo jak w przypadku `fmt.Stringer`, pakiet `fmt` szuka interfejsu `error` gdy drukuje wartości.)
+(Tak samo jak w przypadku `fmt.Stringer`, pakiet `fmt` szuka interfejsu `error` gdy wypisuje wartości.)
 
-Funkcje często zwracają wartość `error`, a blok kodu który wywołuje funkcję powinien 
-dostarczać logikę która testuje czy `error` równa się `nil`.
+Funkcje często zwracają wartość `error`, a kod wywołujący funkcję powinien
+obsłużyć błąd, testując czy `error` jest równy `nil`.
 
 	i, err := strconv.Atoi("42")
 	if err != nil {
@@ -310,74 +301,74 @@ dostarczać logikę która testuje czy `error` równa się `nil`.
 	}
 	fmt.Println("Converted integer:", i)
 
-`error` o wartości nil oznacza sukces; `error` o wartości innej niż nil oznacza porażkę.
+`error` o wartości `nil` oznacza sukces; `error` o wartości innej niż `nil` oznacza porażkę.
 
 .play methods/errors.go
 
 * Ćwiecznie: Errors
 
-Skopiuj swoją funkcję `Sqrt` z [[/flowcontrol/8][wcześniejszego ćwiczenia]] i zmodyfikuj ją tak by zwracała równierz wartość `error`.
+Skopiuj swoją funkcję `Sqrt` z [[/flowcontrol/8][wcześniejszego ćwiczenia]] i zmodyfikuj ją tak by zwracała również wartość typu `error`.
 
-`Sqrt` powinna zwrócić wartość `error` inną niż nil, jeśli numer zwrócony będzie numerem ujemnym. 
+`Sqrt` powinna zwrócić wartość `error` inną niż `nil`, kiedy jej argument liczbowy będzie liczbą ujemną, gdyż funkcja ta nie pracuje z liczbami zespolonymi.
 
 Stwórz nowy typ
 
 	type ErrNegativeSqrt float64
 
-i spraw by był typem `error` po przez
+i spraw by był on interfejsem typu `error` poprzez implementację metody
 
 	func (e ErrNegativeSqrt) Error() string
 
-metodę, tak więc `ErrNegativeSqrt(-2).Error()` zwróci `"cannot`Sqrt`negative`number:`-2"`.
+Jako rezultat wywołania `ErrNegativeSqrt(-2).Error()` powinien zostać zwrócony string `"cannot`Sqrt`negative`number:`-2"`.
 
-*Uwaga:* Wywołanie `fmt.Sprint(e)` wewnątrz metody `Error` spowoduje że program wejdzie w nieskończoną pętle. Możesz tego uniknąć po przez konwersję `e`: `fmt.Sprint(float64(e))`. Dlaczego?
+*Uwaga:* Wywołanie `fmt.Sprint(e)` wewnątrz metody `Error` spowoduje że program wejdzie w nieskończoną pętle. Możesz tego uniknąć po dokonując konwersji `e`: `fmt.Sprint(float64(e))`. Spróbuj odpowiedzieć sobie, dlaczeo tak jest?
 
-Zmień swoją funkcję `Sqrt` tak by zwróciła wartość `ErrNegativeSqrt` gdy otrzyma liczbę ujemną. 
+Zmień swoją funkcję `Sqrt` tak by zwracała wartość typu `ErrNegativeSqrt` gdy otrzyma jako argument liczbę ujemną.
 
 .play methods/exercise-errors.go
 
-* Czytniki (tzw. readers)
+* Czytniki (ang. readers)
 
-Pakiet `io` specyfikuje interfejs `io.Reader`,
-który pozwala na wczytanie wycinka danych.
+Pakiet `io` definiuje interfejs `io.Reader`,
+który pozwala czytać ze strumienia danych.
 
-Standardowa biblioteka Go zawiera [[https://golang.org/search?q=Read#Global][wiele implementacji]] tego właśnie interfejsu, pliki, połączenia sieciowe, kompresory, i inne.
+Standardowa biblioteka Go zawiera [[https://golang.org/search?q=Read#Global][wiele implementacji]] tego interfejsu, między innymi dla plików, połączenia sieciowych, kompresorów danych, szyfrów i innych.
 
-`io.Reader` interfejs zawiera metodę `Read`:
+`io.Reader` interfejs posiada metodę `Read`:
 	func (T) Read(b []byte) (n int, err error)
 
-`Read` populuje wycinek bitów danymi oraz zwraca ten właśnie wycinek bitów oraz error. 
-Zwraca error `io.EOF` gdy ciąg danych się kończy.  
+`Read` zapełnia wycinek wskazujący tablicę bajtów odczytanymi danymi, zwraca zas inta reprezentującego ilość przeczytanych bajtów właśnie wycinek bitów oraz wartość typu `error`. Gdy `Read` dojdzie do końca strumienia danych
+błąd `io.EOF` (błąd końca pliku, ang. end of file error).
 
 Kod podany w przykładzie tworzy
 [[//golang.org/pkg/strings/#Reader][`strings.Reader`]]
-oraz konsumuje jego wynik, 8 bitów po kolei.
+oraz pobiera 8 bajtów ze strumienia przy każdym wywołaniu.
 
 .play methods/reader.go
 
 * Ćwiczenie: Readers
 
-Zaimplementuj typ `Reader` który emituje nieskończony łancuch charakterów ASCII
+Zaimplementuj typ `Reader` który wysyła nieskończony łańcuch znaku ASCII
 `'A'`.
 
 .play methods/exercise-reader.go
 
 * Ćwiczenie: rot13Reader
 
-Ogólnie przyjętym wzorem jest [[https://golang.org/pkg/io/#Reader][io.Reader]] w którym znajduje się kolejny `io.Reader`, modyfikujący w jakiś sposob łancuch danych.
+Często spotykanym schematem postępowania jest tworzenie interfejsu typu [[https://golang.org/pkg/io/#Reader][io.Reader]] wewnątrz którego znajduje się kolejny `io.Reader`, przy czym zewnętrzy interfejs posiada inne metody obsługujące strumień danych.
 
-Na przykład, funkcja [[https://golang.org/pkg/compress/gzip/#NewReader][gzip.NewReader]] przyjmuje `io.Reader` (łancuch skompresowanych danych) oraz zwraca `*gzip.Reader` który równierz implementuje `io.Reader` (lańcuch zdekompresowanych danych).
+Na przykład, funkcja [[https://golang.org/pkg/compress/gzip/#NewReader][gzip.NewReader]] bierze `io.Reader` (strumień skompresowanych danych) i zwraca `*gzip.Reader` który również implementuje `io.Reader` (strumień nieskompresowanych danych).
 
-Zaimplementuj `rot13Reader` który implementuje `io.Reader` oraz czyta z `io.Reader`, modyfikując łancuch po przez zaaplikowanie [[https://en.wikipedia.org/wiki/ROT13][rot13]] szyfru podstawieniowego do wszystkich charakterów alfabetycznych.
+Zaimplementuj `rot13Reader` który implementuje `io.Reader` oraz czyta z tego `io.Reader`, modyfikując otrzymany strumień po przez użycie szyfru podstawieniowego [[https://en.wikipedia.org/wiki/ROT13][rot13]] do wszystkich liter alfabetu.
 
-Typ `rot13Reader` jest już dla ciebie dostarczony.
-Spraw by był on `io.Reader` po przez implementacje jego metody `Read`. 
+Typ `rot13Reader` jest już dla ciebie zdefiniowany.
+Zrób z niego interfejs typu `io.Reader` po przez zaimplementowanie dla niego metody `Read`.
 
 .play methods/exercise-rot-reader.go
 
-* Obrazy (Images)
+* Obrazy (ang. images)
 
-[[https://golang.org/pkg/image/#Image][Pakiet image]] definiuje interfejs `Image`:
+[[https://golang.org/pkg/image/#Image][Pakiet `image`]] definiuje interfejs `Image`:
 
 	package image
 
@@ -387,32 +378,32 @@ Spraw by był on `io.Reader` po przez implementacje jego metody `Read`.
 		At(x, y int) color.Color
 	}
 
-*Uwaga*: `Rectangle` który zwraca wartość metody `Bounds` jest tak naprawde
-[[https://golang.org/pkg/image/#Rectangle][`image.Rectangle`]], ponieważ 
-jego deklaracja jest w środku pakietu `image`.
+*Uwaga*: Dokładniej rzecz biorąc typ wartości zwracanej przez metodę `Bounds` to nie `Rectangle`, lecz
+[[https://golang.org/pkg/image/#Rectangle][`image.Rectangle`]], ponieważ
+jego deklaracja znajduje się w pakiecie `image`.
 
-(Zobacz [[https://golang.org/pkg/image/#Image][tę dokumentację]] by dowiedzieć się więcej.)
+(Zobacz odpowiedni [[https://golang.org/pkg/image/#Image][fragment dokumentacji]] by dowiedzieć się więcej.)
 
-Typy `color.Color` oraz `color.Model` równierz są interfejsami, jednak zignorujemy ten fakt poprzez użycie predefiniowanych implementacji `color.RGBA` oraz `color.RGBAModel`. Te interfejsy oraz typy są specyfikowane przez [[https://golang.org/pkg/image/color/][pakiet image/color]].
+Typy `color.Color` oraz `color.Model` również są interfejsami, jednak zignorujemy ten fakt poprzez użycie zdefiniowanych wcześniej implementacji `color.RGBA` oraz `color.RGBAModel`. Te interfejsy oraz typy dany są zdefiniowane w pakiecie [[https://golang.org/pkg/image/color/][image/color]].
 
 .play methods/images.go
 
 * Ćwiczenie: Images
 
-Pamiętasz [[/moretypes/18][generator obrazów]] który napisałeś wcześniej? Spróbujmy napisać kolejny, tym razem zwróci on implementację `image.Image` zamiast wycinka danych.
+Pamiętasz [[/moretypes/18][generator obrazów]] który napisałeś wcześniej? Spróbujmy napisać kolejny, tym razem zamiast zwracać wycinek danych, zwróci on implementację interfejsu `image.Image`.
 
 Zdefiniuj swój własny typ `Image`, zaimplementuj [[https://golang.org/pkg/image/#Image][wymagane metody]], oraz wywołaj `pic.ShowImage`.
 
-`Bounds` powinny zwrócić `image.Rectangle`, jak na przykład `image.Rect(0,`0,`w,`h)`.
+Metoda `Bounds` powinna zwrócić wartość typu `image.Rectangle`, przykładowo `image.Rect(0,`0,`w,`h)`.
 
-`ColorModel` powinien zwrócić `color.RGBAModel`.
+Metoda `ColorModel` powinna zwrócić `color.RGBAModel`.
 
-`At` powinno zwrócić kolor; wartości `v` w poprzednim generatorze obrazów, w tym odpowiada `color.RGBA{v,`v,`255,`255}`.
+Metoda `At` powinna zwrócić kolor; wartości `v` w poprzednim generatorze obrazów odpowiada teraz wartość `color.RGBA{v,`v,`255,`255}`.
 
 .play methods/exercise-images.go
 
 * Gratulujemy!
 
-Ukończyłeś tą lekcję!
+Ukończyłeś tę lekcję!
 
-Możesz wrócić do listy [[/list][modułów]] by dowiedzieć się czego nauczyć się następnie, lub kontynuować do [[javascript:click('.next-page')][następnej lekcji]].
+Możesz wrócić do listy [[/list][modułów]] by zobaczyć czego więcej możesz się nauczyć, lub od razu przejść do [[javascript:click('.next-page')][następnej lekcji]].

--- a/content/moretypes.article
+++ b/content/moretypes.article
@@ -50,7 +50,7 @@ Jednakże, ta notacja jest niezbyt poręczna, więc Go pozwala użyć nam nastę
 
 .play moretypes/struct-pointers.go
 
-* Struktur literalne (ang. struct literals)
+* Struktury literalne (ang. struct literals)
 
 Struktura literalna oznacza nowo utworzoną wartość zawierającą strukturę poprzez wymiennie wartości jej pól.
 

--- a/content/moretypes.article
+++ b/content/moretypes.article
@@ -1,101 +1,98 @@
-Więcej typów: struktury (structs), wycinki (slices), oraz mapy (maps).
-Naucz się jak zdefniować typy: ta lekcja pokrywa struktury (structs), tablice (arrays), wycinki (slices) oraz mapy (maps).
+Więcej typów: struktury (ang. structs), wycinki (ang. slices), oraz mapy (ang. maps).
+Naucz się jak zdefiniować nowe typy dany. Ta lekcja omawia struktury (ang. structs), tablice (ang. arrays), wycinki (ang. slices) oraz mapy (ang. maps).
 
 Autorzy Go
 https://golang.org
 
-* Wskaźniki (tzw. pointers)
+* Wskaźniki (ang. pointers)
 
 Go posiada wskaźniki.
-Wskaźnik przetrzymuje adres w pamięci danej wartości.
+Wskaźnik przechowuje adres pamięci w której znajduje się dana wartość.
 
-Typ `*T` to wksaźnik do wartości `T`. Jego wartość zerowa wynosi `nil`.
+Typ `*T` to wskaźnik do wartości o typie `T`. Jego wartość zerowa wynosi `nil`.
 
 	var p *int
 
-`&` operator generuje wskaźnik do jego operanda.
+`&` operator generuje wskaźnik do jego operandy.
 
 	i := 42
 	p = &i
 
-Operator `*` określa wartość bazowa wskaźnika.
+Operator `*` oznacza wartość wskazywaną w pamięci przez dany wskaźnika.
 
-	fmt.Println(*p) // przyczytaj i poprzez wskaźnik p
-	*p = 21         // ustaw i poprzez wskaźnik p
+	fmt.Println(*p) // odczytuje wartość i poprzez wskaźnik p
+	*p = 21         // ustawia wartość i poprzez wskaźnik p
 
-Znane jest to jako "dereferencja"(tzw. dereferencing) lub "pośrednictwo"(tzw. indirecting).
+Powyższa własność nazywana jest „dereferencją” (ang. dereferencing) lub „pośrednictwo” (ang. indirecting).
 
-W przeciwieństwie do C, Go nie ma wskaźnika arytmetycznego.
+W przeciwieństwie do C, Go nie ma arytmetyki wskaźników.
 
 .play moretypes/pointers.go
 
-* Struktury (tzw. structs)
+* Struktury (ang. structs)
 
-`struct` jest kolekcją pól. 
+`struct` jest zbiorem pól (ang. fields).
 
 .play moretypes/structs.go
 
-* Pola Struktur (Struct Fields)
+* Pola struktur (ang. struct fields)
 
-Aby uzyskać dostęp do pola stuktury używamy kropki.
+Aby uzyskać dostęp do pola struktury używamy kropki.
 
 .play moretypes/struct-fields.go
 
-* Wskaźniki do struktur (Pointers to structs)
+* Wskaźniki do struktur (ang. pointers to structs)
 
-Pola struktury mogą być rownierz osiągnięte poprzez użycie wskaźnika struktury.
+Do pół struktury możemy się również dostać za pomocą wskaźnika do struktury.
 
-By uzyskać dostęp do pola `X` w danej strukturze gdy mamy wskaźnik struktury `p`, możemy 
-napisać `(*p).X`. 
-Jednakże, ta notacja jest niezbyt poręczna, więc Go, pozwala użyć nam następującej notacji
-`p.X`, czyli bez uwzględniania jawnej derefencji. 
+By uzyskać dostęp do pola `X` danej strukturze, którą wskazuje wskaźnik do struktury `p`, możemy napisać `(*p).X`.
+Jednakże, ta notacja jest niezbyt poręczna, więc Go pozwala użyć nam następującej składni: `p.X`. W tym przypadku Go pozwala nam opuścić jawną dereferencję.
 
 .play moretypes/struct-pointers.go
 
-* Literały Struktur (tzw. struct literals)
+* Struktur literalne (ang. struct literals)
 
-Literał stuktury oznacza przydzielanie wartości po przez wymienianie kolejno pól struktury.
+Struktura literalna oznacza nowo utworzoną wartość zawierającą strukturę poprzez wymiennie wartości jej pól.
 
-Możesz przypisać wartości pól poprzez użycie `Name:`. ( Porządek pól nie ma znaczenia )
+Możesz przypisać wartości tylko części pól, poprzez użycie składni `Name:`. Porządek nazwany pól nie ma znaczenia.
 
-Prefix `&` zwraca wskaźnik do wartości stuktury.
+Prefiks `&` zwraca wskaźnik do wartości struktury.
 
 .play moretypes/struct-literals.go
 
 
-* Tablice (tzw. arrays)
+* Tablice (ang. arrays)
 
-Typ `[n]T` jest tablicą która zawiera wartości `n` typu `T`.
+Typ `[n]T` jest tablicą która zawiera `n` wartości typu `T`.
 
 Wyrażenie
 
 	var a [10]int
 
-deklaruje zmienna `a` jako tablice zawierającą dziesięć integerów (liczbowy typ danych). 
+deklaruje zmienną `a` jako tablice zawierającą dziesięć intów (liczb całkowitych).
 
-Długość tablicy jest częścią jej typu, tak więc rozmiar tablicy nie może być zmieniany. 
-To może wydawać się niedogodne, jednak nie martw się;
+Długość tablicy jest częścią jej typu, tak więc rozmiar tablicy nie może być zmieniany.
+To może wydawać się niewygodne, jednak nie należy się martwić;
 Go posiada wiele wygodnych sposobów na pracę z tablicami.
 
 .play moretypes/array.go
 
-* Wycinki (tzw. slices)
+* Wycinki (ang. slices)
 
-Tablice mają określony rozmiar.
-Wycinki znów, poznawalają na dynamiczną, elastyczną pracę z tablicami.
-W praktyce, wycinki są dużo cześciej używane niżeli tablice.
+Tablice mają ustaloną długość. Natomiast wycinki (ang. slices)
+są elastycznym w użyciu podglądem (ang. view) na elementy tablicy, których długość możemy dynamicznie zmieniać tablicami.
+W praktyce, wycinki są używane dużo częściej niż tablice.
 
-Type `[]T` jest wycinkiem z elementami o typie `T`.
+Type `[]T` jest wycinkiem z elementami o typie `T`. Składnię `[]T` czytamy: „jest to wycinek tablicy o wartościach typu `T`”, patrz [[javascript:click('.next-page')][następny slajd]].
 
-Wycinek jest stworzony poprzez określenie dwóch indeksów, dolnego (low)
-oraz górnego (high) ograniczenia, oddzielonego dwukropiem:
+Wycinek jest tworzony poprzez wybranie dwóch indeksów, dolnego (ang. low)
+oraz górnego (ang. high) oddzielonych dwukropkiem:
 
 	a[low : high]
 
-Wyrażnie powyżej specyfikuje zasięg elemntów który zawiera 
-pierwszy element, lecz wyklucza ostatni.
+Wyrażenie powyżej określa zakres elementów danego wycinka. Wycinek zawiera elementy od granicy dolnej `a[low]` do granicy górnej `a[high]`, z wyłączeniem ostatniego elementu.
 
-Następujące wyrażenie tworzy wycinek który zawiera elementy od 1 do 3 z `a`:
+Następujące wyrażenie tworzy wycinek który zawiera elementy `a` od 1 do 3:
 
 	a[1:4]
 
@@ -104,44 +101,41 @@ Następujące wyrażenie tworzy wycinek który zawiera elementy od 1 do 3 z `a`:
 
 * Wycinki są jak referencje do tablic
 
-Wycinek nie przetrzymuje żadnych danych,
-lecz określa sekcje danej tablicy.
+Wycinek nie przechowuje żadnych danych, tylko wskazuje na fragment pewnej tablicy.
 
-Zmienianie wartości wycinka modyfikuje dany element 
-z danej tablicy.
+Zmienianie wartości danego wycinka zmienia wartość elementu tablicy na którą wycinek wskazuje.
 
-Inne wycinki które równierz nawiązuja do tej samej tablicy będa odzwierciedlały dokonane zmiany.
+Inne wycinki które wskazują na tę samą tablicę, będą widziały dokonane zmiany.
 
 .play moretypes/slices-pointers.go
 
 
-* Literały wycinków  (tzw. slice literals)
+* Wycinki literalne  (ang. slice literals)
 
-Literał wycinków jest jak literał tablicy bez długości.
+Wycinek literalny wygląda jak tablica literalna bez podanej długości.
 
-Oto literał tablicy:
+Oto tablica literalna:
 
 	[3]bool{true, true, false}
 
-A to tworzy taką samą tablicę jak powyżej,
-oraz tworzy wycinek który odnosi się do niej:
+Teraz zbudujemy taką samą tablicę jak powyżej, ale od razu utworzymy wycinek który odnosi się do niej:
 
 	[]bool{true, true, false}
 
 .play moretypes/slice-literals.go
 
 
-* Wycinki domyślne (tzw. slice defaults)
+* Wycinki domyślne (ang. slice defaults)
 
-Gdy tworzymy wycinki, można pominąć wysokie lub niskie granice by użyć wartości domyślnych.
+Gdy tworzymy wycinki, można pominąć dolną lub górną granice, wtedy zostaną użyte ich wartości domyślne.
 
-Wartość domyślna dla dolniej granicy wynosi zero, wartość górna granicy jest równa długości tablicy.
+Wartość domyślna dla dolnej granicy wynosi zero, wartość granicy górnej jest równa długości tablicy.
 
 Dla poniżej tablicy:
 
 	var a [10]int
 
-te wartości wycinków są identyczne:
+te poniższe wyrażenia tworzące wycinki są równoważne:
 
 	a[0:10]
 	a[:10]
@@ -153,60 +147,56 @@ te wartości wycinków są identyczne:
 
 * Długości i pojemność wycinków
 
-Wycinek posiada _długość_ (length) oraz _pojemność_ (capacity).
+Wycinek posiada zarówno _długość_ (ang. length) jak i _pojemność_ (ang. capacity).
 
-Długość(len) wycinka to liczba elemntów które posiada.
+Długość (ang. len) wycinka to liczba elementów które posiada.
 
-Pojemność(cap) wycinków to liczba elementów tablicy do której dany wycinek nawiązuje,
-licząc od pierwszego elementu w wycinku.
+Pojemność (ang. cap) wycinka to liczba elementów tablicy na którą dany wycinek wskazuje, licząc od pierwszego elementu wycinka.
 
-Dlugość i pojemność wycinka `s` może zostać uzyskana po przez użycie wyrażenia
+Długość i pojemność wycinka `s` może zostać uzyskana po przez użycie wyrażenia
 `len(s)` oraz `cap(s)`.
 
-Możesz zwiększyć długość wycinka poprzez tworzenie z niego kolejnego wycinka (tzw. re-slicing),
-jeśli tylko dany wycinek posiada wymaganą pojemność.
-Spróbuj zmienić jeden z wycinków w przykładowym programie, tak by wykroczyć poza jego pojemność
-i zobacz co się stanie.
+Jeśli tylko dany wycinek posiada odpowiednią pojemność, możemy zwiększyć jego długość poprzez wycięcie z niego kolejnego wycinka (ang. re-slicing).
+Spróbuj zmienić jeden z wycinków w przykładowym programie, tak by przekroczyć jego pojemność i zobacz co się stanie.
 
 .play moretypes/slice-len-cap.go
 
 
-* Wycinki zerowe (Nil slices)
+* Wycinki zerowe (ang. nil slices)
 
 Wartość zerowa wycinka to `nil`.
 
-Wycinek `nil` ma długość oraz pojemność równa 0 oraz 
-nie posiada żadnej tablicy odnośnej.
+Wycinek `nil` ma długość oraz pojemność równą 0 oraz
+nie wskazuje na żadną tablicę.
 
 .play moretypes/nil-slices.go
 
 
 * Tworzenie wycinka za pomocą `make`
 
-Wycinki mogą być stworzone poprzez wbudowana funkcję `make`;
-tak właśnie tworzy się dynamiczne tablice.
+Wycinki mogą być utworzone za pomocą wbudowanej funkcji `make`;
+tak właśnie tworzymy tablice o dynamicznej długości.
 
-Funkcja `make` przydziela zerową tablice oraz 
-zwraca wycinek który odnosi się do tej tablicy:
+Funkcja `make` tworzy tablicę o wyzerowanych wartościach elementów oraz zwraca wycinek który na nią wskazuje:
 
 	a := make([]int, 5)  // len(a)=5
 
-By określić pojemność, wystarczy podać trzeci argument do funkcji `make`:
+By określić pojemność, wystarczy dodać trzeci argument do funkcji `make`:
 
-	b := make([]int, 0, 5) // len(b)=0, cap(b)=5
+	b := make([]int, 0, 5) // len(b) = 0, cap(b) = 5
 
-	b = b[:cap(b)] // len(b)=5, cap(b)=5
-	b = b[1:]      // len(b)=4, cap(b)=4
+	b = b[:cap(b)] // len(b) = 5, cap(b) = 5
+	b = b[1:]      // len(b) = 4, cap(b) = 4
 
 .play moretypes/making-slices.go
 
 
 * Wycinki wycinków
 
-Wycinki mogą zawierać każdy typ, tak równierz jak i inne wycinki.
+Wycinki mogą zawierać jako swój element każdy typ, włączając w to inne wycinki.
 
 .play moretypes/slices-of-slice.go
-
+??????????????????????????????
 
 * Dołączanie do wycinka
 
@@ -215,37 +205,34 @@ Bardzo często zdarza się że chcemy dodać nowy element do wycinka, Go posiada
 
 	func append(s []T, vs ...T) []T
 
-Pierwszy parametr `s` funckcji `append` jest wycinek o typie `T`, a reszta parametrów to 
-wartości `T` które chcemy dołączyć do wycinka.
+Pierwszy parametr funkcji `append` jest wycinek `s` o typie `T`, pozostałe parametrów to wartości typu `T` które chcemy dołączyć do wycinka.
 
-Rezultatem funkcji `append` jest wycinek zawierający wszystkie elementy oryginalnego wycinka 
-oraz dodatkowe elementy.
+Rezultatem funkcji `append` jest wycinek zawierający wszystkie elementy oryginalnego wycinka oraz dodatkowe elementy.
 
-Jeśli tablica odpowiadająca wartości `s` jest zbyt mała by pomieścić wszystkie wartości, nowa, większa tablica
-zostanie utworzona. Zwrócony wycinek będzie wskazywał nowo przydzieloną tablice.
+Jeśli tablica na którą wskazuje `s` jest zbyt mała by pomieścić wszystkie wartości, nowa, większa tablica zostanie utworzona. Zwrócony wycinek będzie wskazywał na nowo przydzieloną tablice.
 
-(By nauczyć się więcej o wycinkach, przeczytaj artykuł [[https://blog.golang.org/go-slices-usage-and-internals][Slices: usage and internals]])
+(By dowiedzieć się więcej o wycinkach, przeczytaj artykuł [[https://blog.golang.org/go-slices-usage-and-internals][Slices: usage and internals]]).
 
 .play moretypes/append.go
 
 
-* Zakres (tzw. range)
+* Zakres (ang. range)
 
-`range` z pętli(`for`) iteruje poprzez mapę(tzw. map) lub wycinek(tzw. slice).
+Słowo kluczowe `range` używane w pętli `for` pozwala nam iterować po wycinku (ang. slice) lub mapie (ang. map).
 
-Gdy przechodzimy przez zakres wycinka, dwie wartości są zwrócone przy każdej iteracji.
-Pierwszą jest indeks, a drugą jest kopia elementu o tym właśnie indeksie.
+Gdy iterujemy po zakresie wycinka, w każdym kroku są zwracane dwie wartości.
+Pierwszą jest indeks elementu wycinka, a drugą jest kopia tego elementu o tym indeksie.
 
 .play moretypes/range.go
 
-* Zakres ciąg dalszy
+* Zakres, ciąg dalszy
 
-Możesz pominąć indeks lub wartość zwrotu poprzez `_`.
+Możesz pominąć indeks lub wartość elementu poprzez przypisanie ich do `_`.
 
     for i, _ := range pow
     for _, value := range pow
 
-Jeśli chcesz otrzymać tylko indeks, możesz pominąć wartość: 
+Jeśli chcesz otrzymać tylko indeks, możesz zupełnie pominąć wartość elementu.
 
     for i := range pow
 
@@ -253,63 +240,62 @@ Jeśli chcesz otrzymać tylko indeks, możesz pominąć wartość:
 
 * Ćwiczenie: Wycinki
 
-Zaimplementuj `Pic`. Powinnien on zwrócić wycinek o długości `dy`, każdy element tego wycinka powinien być wycinkiem `dx`  8-bitowych unsigned-integers. Gdy uruchomisz program, wyświetli on obrazek, interpretując wartości integerów w skali szarości.
+Zaimplementuj funkcję `Pic`. Powinna ona zwrócić wycinek o długości `dy`, którego elementami są wycinki wycinkiem zawierający `dx` 8-bitowych liczb całkowitych bez znaku (ang. 8-bit unisgned integer). Gdy uruchomisz program, wyświetli on obrazek, interpretując wartości intów w skali szarości (tak naprawdę, to w skali „niebieskości”).
 
-Wybór obrazka należy do ciebie. Funkcje które mogą cię zainteresowac: `(x+y)/2`, `x*y`, and `x^y`.
+Wybór obrazka należy do ciebie. Przykładowe funkcje które dają ciekawy rezultat to: `(x+y)/2`, `x*y`, and `x^y`.
 
-(Musisz użyć pętli by przypisać każdą wartość `[]uint8` w wewnątrz `[][]uint8`.)
+(Musisz użyć pętli by przypisać każdemu elementowi w `[][]uint8` wartość `[]uint8`.)
 
-(Użyj `uint8(intValue)` by zmieniać(konwertować) typy)
+(Użyj `uint8(intValue)` by dokonać konwersji typów.)
 
 .play moretypes/exercise-slices.go
 
-* Mapy (Maps)
+* Mapy (ang. maps)
 
-Mapa mapuje klucze do wartości.
+Mapa przyporządkowuje kluczom odpowiednie wartości.
 
 Wartość zerowa mapy to `nil`.
-Mapa `nil` nie posiada kluczy, tak równierz, jak i klucze nie mogą być dodane.
+Mapa `nil` nie posiada kluczy i żaden klucz nie może być do niej dodany.
 
-Funkcja `make` zwraca mapę danego typu,
-zaincjanowaną i gotową do użytku.
+Funkcja `make` zwraca mapę danego typu, zaincjalizowaną i gotową do użytku.
 
 .play moretypes/maps.go
 
-* Literały map (tzw. map literals)
+* Mapy literalne (ang. map literals)
 
-Literały map są podobne do literałów struktór, jednak klucze są wymage.
+Mapy literalne są podobne do struktur literalnych, ale podanie kluczy jest konieczne.
 
 .play moretypes/map-literals.go
 
-* Literały map ciąg dalszy
+* Mapy literalne ciąg dalszy
 
-Jeśli typ użyty jest tylko nazwą typu, możesz pominać element literału.
+Jeśli typ elementu zwracanego przez mapę jest po prostu nazwą typu, możesz pominąć w deklaracjach elementów mapy literalnej.
 
 .play moretypes/map-literals-continued.go
 
-* Mutowanie map
+* Modyfikacja map
 
-Wstaw lub zaktualizuj element w mapie `m`:
+Wstawianie lub aktualizacja elementu w mapie `m`:
 
 	m[key] = elem
 
-Odzyskaj element: 
+Pobranie elementu:
 
 	elem = m[key]
 
-Usuń element:
+Usunięcie elementu:
 
 	delete(m, key)
 
-Sprawdź czy dany klucz znajduje się w mapie poprzez przypisanie rezultatowi dwóch elementów:
+Sprawdzenie czy mapa zawiera dany klucz poprzez przypisanie wyniku do dwóch zmiennych:
 
 	elem, ok = m[key]
 
-Jeśli `key` znajduje się w mapie `m`, `ok` jest wartością `true`. Jeśli nie, `ok` jest równe `false`.
+Jeśli mapa `m` zawiera klucz `key` mapie `m`, `ok` ma wartość `true`. Jeśli nie, `ok` jest równe `false`.
 
-Jeśli `key` nie znajduje się w mapie, wtedy `elem` jest wartością zerową dla typu elementu mapy. 
+Jeśli mapa nie zawiera klucza `key`, wówczas `elem` przyjmuje wartość zerową typu elementu mapy.
 
-*Uwaga:* Jeśli `elem` lub `ok` nie zostało zadeklarowane, możesz użyc formy deklaracji krótkiej:
+*Uwaga:* Jeśli `elem` lub `ok` nie zostały zadeklarowane, możesz użyć krótkiej formy deklaracji.
 
 	elem, ok := m[key]
 
@@ -317,40 +303,41 @@ Jeśli `key` nie znajduje się w mapie, wtedy `elem` jest wartością zerową dl
 
 * Ćwiczenie: Mapy
 
-Zaimplementuj `WordCount`.  Program powinien zwrócić mapę która policzy każde "słowo" w stringu `s`. Funkcja `wc.Test` puszcza test twojej funkcji i zwraca "success"(sukces) lub "failure"(porażka)
+Zaimplementuj `WordCount`.  Program powinien zwrócić mapę która policzy ilość wystąpień każdego "wyrazu" w stringu `s`. Funkcja `wc.Test` uruchamia test twojej funkcji i wypisuje na ekranie "success" (pl. sukces) lub "failure" (pl. porażka).
 
-Ten materiał może ci pomóc [[https://golang.org/pkg/strings/#Fields][strings.Fields]].
+W tym ćwiczeniu może okazać się pomocne zapoznanie się z funkcją
+[[https://golang.org/pkg/strings/#Fields][strings.Fields]].
 
 .play moretypes/exercise-maps.go
 
 * Wartości funkcji
 
-Funkcje są równierz wartościami. Mogą zostać przekazywane tak samo jak inne wartości.
+Funkcje również są wartościami. Mogą zostać przekazywane tak samo jak wszystkie inne wartości.
 
-Wartości funkcji mogą być użyte jako argumenty funkcji oraz wartości zwrócone.
+Wartości będące funkcjami mogą być użyte jako argumenty funkcji oraz wartości zwracane.
 
 .play moretypes/function-values.go
 
-* Domknięcia funkcji (tzw. function closures)
+* Domknięcia funkcji (ang. function closures)
 
-Funkcje w Go mogą być domknięciami. Domknięcie to wartość funkcji która odnosi się do zmiennych które znajdują się poza kodem zawartym w funkcji. Funkcja ma dostęp do wspomnianych zmiennych; w tym sensie funkcja jest "powiązana" z zmiennymi.
+Funkcje w Go mogą być domknięciami. Domknięcie to funkcji będąca wartością która odnosi się do zmiennych które będący poza jej ciałem. Funkcja ma dostęp do wspomnianych zmiennych; w tym sensie funkcja jest „powiązana” z tymi zmiennymi.
 
-Na przykład, funkcja `adder` zwraca domknięcie. Każde domknięcie jest połączone z własną zmienną `sum`.
+Przykładowo, funkcja `adder` zwraca domknięcie. Każde domknięcie jest powiązana z swoją własną zmienną `sum`.
 
 .play moretypes/function-closures.go
 
-* Ćwiczenie: Domknięcie Fibonacci
+* Ćwiczenie: Domknięcie fibonacci
 
-Zabawmy się z funkcjami.
+Pobawmy się trochę funkcjami.
 
-Zaimplementuj funkcję `fibonacci` która zwróci funkcję (domknięcie) która zwróci 
-[[https://en.wikipedia.org/wiki/Fibonacci_number][liczby fibonacciego]]
+Zaimplementuj funkcję `fibonacci` która zwróci funkcję (domknięcie) która zwraca ciąg
+[[https://en.wikipedia.org/wiki/Fibonacci_number][liczby Fibonacciego]]
 (0, 1, 1, 2, 3, 5, ...).
 
 .play moretypes/exercise-fibonacci-closure.go
 
 * Gratulujemy!
 
-Ukończyłeś tą lekcję!
+Ukończyłeś tę lekcję!
 
-Możesz wrócić do listy [[/list][modułów]] by dowiedzieć się czego nauczyć się następnie, lub kontynuować do [[javascript:click('.next-page')][następnej lekcji]].
+Możesz wrócić do listy [[/list][modułów]] by dowiedzieć się czego nauczyć się następnie, lub kontynuować do [[javascript:click('.next-page')][następnej lekcji]]

--- a/content/moretypes.article
+++ b/content/moretypes.article
@@ -1,5 +1,5 @@
 Więcej typów: struktury (ang. structs), wycinki (ang. slices), oraz mapy (ang. maps).
-Naucz się jak zdefiniować nowe typy dany. Ta lekcja omawia struktury (ang. structs), tablice (ang. arrays), wycinki (ang. slices) oraz mapy (ang. maps).
+Naucz się jak zdefiniować nowe typy danych. Ta lekcja omawia struktury (ang. structs), tablice (ang. arrays), wycinki (ang. slices) oraz mapy (ang. maps).
 
 Autorzy Go
 https://golang.org
@@ -23,7 +23,7 @@ Operator `*` oznacza wartość wskazywaną w pamięci przez dany wskaźnika.
 	fmt.Println(*p) // odczytuje wartość i poprzez wskaźnik p
 	*p = 21         // ustawia wartość i poprzez wskaźnik p
 
-Powyższa własność nazywana jest „dereferencją” (ang. dereferencing) lub „pośrednictwo” (ang. indirecting).
+Powyższa własność nazywana jest „dereferencją” (ang. dereferencing) lub „pośrednictwem” (ang. indirecting).
 
 W przeciwieństwie do C, Go nie ma arytmetyki wskaźników.
 
@@ -43,10 +43,10 @@ Aby uzyskać dostęp do pola struktury używamy kropki.
 
 * Wskaźniki do struktur (ang. pointers to structs)
 
-Do pół struktury możemy się również dostać za pomocą wskaźnika do struktury.
+Do pól struktury możemy się również dostać za pomocą wskaźnika do struktury.
 
-By uzyskać dostęp do pola `X` danej strukturze, którą wskazuje wskaźnik do struktury `p`, możemy napisać `(*p).X`.
-Jednakże, ta notacja jest niezbyt poręczna, więc Go pozwala użyć nam następującej składni: `p.X`. W tym przypadku Go pozwala nam opuścić jawną dereferencję.
+By uzyskać dostęp do pola `X` struktury którą wskazuje wskaźnik do struktury `p`, możemy napisać `(*p).X`.
+Jednakże, ta notacja jest niezbyt poręczna, więc Go pozwala użyć nam następującej składni: `p.X`. W tym przypadku Go pozwala nam opuścić jawną dereferencję wskaźnika.
 
 .play moretypes/struct-pointers.go
 
@@ -72,7 +72,7 @@ Wyrażenie
 deklaruje zmienną `a` jako tablice zawierającą dziesięć intów (liczb całkowitych).
 
 Długość tablicy jest częścią jej typu, tak więc rozmiar tablicy nie może być zmieniany.
-To może wydawać się niewygodne, jednak nie należy się martwić;
+To może wydawać się niewygodne, jednak nie należy się tym martwić;
 Go posiada wiele wygodnych sposobów na pracę z tablicami.
 
 .play moretypes/array.go
@@ -80,7 +80,7 @@ Go posiada wiele wygodnych sposobów na pracę z tablicami.
 * Wycinki (ang. slices)
 
 Tablice mają ustaloną długość. Natomiast wycinki (ang. slices)
-są elastycznym w użyciu podglądem (ang. view) na elementy tablicy, których długość możemy dynamicznie zmieniać tablicami.
+są elastycznym w użyciu podglądem (ang. view) na elementy pewnej tablicy, których długość możemy dynamicznie zmieniać.
 W praktyce, wycinki są używane dużo częściej niż tablice.
 
 Type `[]T` jest wycinkiem z elementami o typie `T`. Składnię `[]T` czytamy: „jest to wycinek tablicy o wartościach typu `T`”, patrz [[javascript:click('.next-page')][następny slajd]].
@@ -135,7 +135,7 @@ Dla poniżej tablicy:
 
 	var a [10]int
 
-te poniższe wyrażenia tworzące wycinki są równoważne:
+poniższe wyrażenia tworzące wycinki są równoważne:
 
 	a[0:10]
 	a[:10]
@@ -149,11 +149,11 @@ te poniższe wyrażenia tworzące wycinki są równoważne:
 
 Wycinek posiada zarówno _długość_ (ang. length) jak i _pojemność_ (ang. capacity).
 
-Długość (ang. len) wycinka to liczba elementów które posiada.
+Długość (ang. len) wycinka to liczba elementów na które wskazuje.
 
 Pojemność (ang. cap) wycinka to liczba elementów tablicy na którą dany wycinek wskazuje, licząc od pierwszego elementu wycinka.
 
-Długość i pojemność wycinka `s` może zostać uzyskana po przez użycie wyrażenia
+Długość i pojemność wycinka `s` może zostać uzyskana po przez użycie wyrażeń
 `len(s)` oraz `cap(s)`.
 
 Jeśli tylko dany wycinek posiada odpowiednią pojemność, możemy zwiększyć jego długość poprzez wycięcie z niego kolejnego wycinka (ang. re-slicing).
@@ -196,7 +196,6 @@ By określić pojemność, wystarczy dodać trzeci argument do funkcji `make`:
 Wycinki mogą zawierać jako swój element każdy typ, włączając w to inne wycinki.
 
 .play moretypes/slices-of-slice.go
-??????????????????????????????
 
 * Dołączanie do wycinka
 
@@ -205,7 +204,7 @@ Bardzo często zdarza się że chcemy dodać nowy element do wycinka, Go posiada
 
 	func append(s []T, vs ...T) []T
 
-Pierwszy parametr funkcji `append` jest wycinek `s` o typie `T`, pozostałe parametrów to wartości typu `T` które chcemy dołączyć do wycinka.
+Pierwszym parametrem funkcji `append` jest wycinek `s` o typie `T`, pozostałe parametry to wartości typu `T` które chcemy dołączyć do wycinka.
 
 Rezultatem funkcji `append` jest wycinek zawierający wszystkie elementy oryginalnego wycinka oraz dodatkowe elementy.
 
@@ -221,7 +220,7 @@ Jeśli tablica na którą wskazuje `s` jest zbyt mała by pomieścić wszystkie 
 Słowo kluczowe `range` używane w pętli `for` pozwala nam iterować po wycinku (ang. slice) lub mapie (ang. map).
 
 Gdy iterujemy po zakresie wycinka, w każdym kroku są zwracane dwie wartości.
-Pierwszą jest indeks elementu wycinka, a drugą jest kopia tego elementu o tym indeksie.
+Pierwszą jest indeks elementu wycinka, a drugą jest kopia elementu o tym indeksie.
 
 .play moretypes/range.go
 
@@ -240,11 +239,11 @@ Jeśli chcesz otrzymać tylko indeks, możesz zupełnie pominąć wartość elem
 
 * Ćwiczenie: Wycinki
 
-Zaimplementuj funkcję `Pic`. Powinna ona zwrócić wycinek o długości `dy`, którego elementami są wycinki wycinkiem zawierający `dx` 8-bitowych liczb całkowitych bez znaku (ang. 8-bit unisgned integer). Gdy uruchomisz program, wyświetli on obrazek, interpretując wartości intów w skali szarości (tak naprawdę, to w skali „niebieskości”).
+Zaimplementuj funkcję `Pic`. Powinna ona zwrócić wycinek o długości `dy`, którego elementami są wycinki zawierające `dx` 8-bitowych liczb całkowitych bez znaku (ang. 8-bit unisgned integer). Gdy uruchomisz program, wyświetli on obrazek, interpretując wartości intów w skali szarości (tak naprawdę, to w skali „niebieskości”).
 
 Wybór obrazka należy do ciebie. Przykładowe funkcje które dają ciekawy rezultat to: `(x+y)/2`, `x*y`, and `x^y`.
 
-(Musisz użyć pętli by przypisać każdemu elementowi w `[][]uint8` wartość `[]uint8`.)
+(Musisz użyć pętli by przypisać każdemu elementowi w `[][]uint8` wartość typu `[]uint8`.)
 
 (Użyj `uint8(intValue)` by dokonać konwersji typów.)
 
@@ -269,7 +268,7 @@ Mapy literalne są podobne do struktur literalnych, ale podanie kluczy jest koni
 
 * Mapy literalne ciąg dalszy
 
-Jeśli typ elementu zwracanego przez mapę jest po prostu nazwą typu, możesz pominąć w deklaracjach elementów mapy literalnej.
+Jeśli typ elementu zwracanego przez mapę jest po prostu nazwą typu, możesz pominąć typ w deklaracjach elementów mapy literalnej.
 
 .play moretypes/map-literals-continued.go
 
@@ -320,9 +319,9 @@ Wartości będące funkcjami mogą być użyte jako argumenty funkcji oraz warto
 
 * Domknięcia funkcji (ang. function closures)
 
-Funkcje w Go mogą być domknięciami. Domknięcie to funkcji będąca wartością która odnosi się do zmiennych które będący poza jej ciałem. Funkcja ma dostęp do wspomnianych zmiennych; w tym sensie funkcja jest „powiązana” z tymi zmiennymi.
+Funkcje w Go mogą być domknięciami. Domknięcie to funkcji będąca wartością która odnosi się do zmiennych znajdujących się poza jej ciałem. Funkcja ma dostęp do wspomnianych zmiennych; w tym sensie funkcja jest „powiązana” z tymi zmiennymi.
 
-Przykładowo, funkcja `adder` zwraca domknięcie. Każde domknięcie jest powiązana z swoją własną zmienną `sum`.
+Przykładowo, funkcja `adder` zwraca domknięcie. Każde domknięcie jest powiązane ze swoją własną zmienną `sum`.
 
 .play moretypes/function-closures.go
 

--- a/content/welcome.article
+++ b/content/welcome.article
@@ -99,4 +99,4 @@ Naciśnij przycisk [[javascript:highlightAndClick(".next-page")]["dalej"]] lub `
 
 Właśnie ukończyłeś swój pierwszy moduł Przewodnika po Go!
 
-Kliknij na [[javascript:highlightAndClick(".logo")][Przewodnik po Go]] by dowiedzieć się czego więcej możesz się nauczyć, lub od razu przejdź do [[javascript:click('.next-page')][następnej lekcji]].
+Kliknij na [[javascript:highlightAndClick(".logo")][Przewodnik po Go]] by zobaczyć czego więcej możesz się nauczyć, lub od razu przejdź do [[javascript:click('.next-page')][następnej lekcji]].

--- a/content/welcome.article
+++ b/content/welcome.article
@@ -1,98 +1,98 @@
 Witamy!
-Naucz się jak używać Przewodnika po Go: wliczając instruckcje jak nawigować poprzez różne lekcje oraz jak uruchomić kod.
+Naucz się jak używać Przewodnika po Go: wliczając w to instrukcje jak poruszać się między lekcje oraz jak uruchomić kod.
 
 Autorzy Go
 https://golang.org
 
 * Cześć!
 
-Witamy w przewodniku [[https://golang.org/][języka Go]].
+Witamy na przewodniku po [[https://golang.org/][języku Go]].
 
-Przewodnik podzielony jest na listę modułów do których możesz przejść
+Przewodnik jest podzielony na listę modułów do których możesz przejść
 klikając na logo
-[[javascript:highlight(".logo")][Przewodnik po Go]] na górze po lewej stronie.
- 
-W dowolnym momencie mozesz równierz zobaczyć spis treści poprzez kliknięcie na [[javascript:highlightAndClick(".nav")][menu]] w prawym górnym rogu ekranu.
+[[javascript:highlight(".logo")][Przewodnik po Go]] w lewym górnym rogu ekranu.
 
-W przewodniku po Go zostaniesz pokierowany przez serię slidów i ćwiczeń które będziesz mógł wykonać.
+W dowolnym momencie możesz zobaczyć spis treści poprzez kliknięcie na [[javascript:highlightAndClick(".nav")][menu]] w prawym górnym rogu ekranu.
 
-Możesz równierz nawigować poprzez slidy za pomocą przycisku
+W przewodniku po Go zapoznasz się z serią slajdów i ćwiczeń które będziesz mógł wykonać.
+
+Możesz również poruszać się między slajdami za pomocą przycisku
 
 - [[javascript:highlight(".prev-page")]["poprzedni"]] lub `PageUp` by wrócić do poprzedniej strony,
 
-- [[javascript:highlight(".next-page")]["nastepny"]] lub `PageDown` by przejść do następnej strony.
+- [[javascript:highlight(".next-page")]["następny"]] lub `PageDown` by przejść do następnej strony.
 
-Przewodnik jest interaktywny. Kliknij na
+Ten przewodnik jest interaktywny. Kliknij na
 [[javascript:highlightAndClick("#run")][Run]]
-(lub wciśnij `Shift` + `Enter`) by zkompilować i uruchomić swój program na
+(lub wciśnij `Shift` + `Enter`) by skompilować i uruchomić swój program na
 #appengine: zdalnym serwerze.
-Rezultat będzie wyświetlony poniżej kodu.
+Rezultat zostanie wyświetlony poniżej kodu.
 
-Te przykładowe programy demonstrują różne aspekty Go. Programy w Wycieczce po Go mają na celu być punktem startowym twych własnych eksperymentów z Go!
+Przykładowe programy tu zawarte prezentują różne aspekty języka Go. Programy w Przewodniku po Go są pomyślane jako punkt startowym twoich własnych eksperymentów z Go!
 
 Edytuj program i uruchom go ponownie.
 
 Gdy klikniesz na [[javascript:highlightAndClick("#format")][Format]]
-(skrót: `Ctrl` + `Enter`), tekst w edytorze zostanie zformatowany używając
-[[https://golang.org/cmd/gofmt/][gofmt]] narzędzia. Możesz włączyć lub wyłączyć podświetlanie
-kodu używając przycisku [[javascript:highlightAndClick(".syntax-checkbox")][syntax]].
+(skrót: `Ctrl` + `Enter`), tekst w edytorze zostanie sformatowany za pomocą narzędzia [[https://golang.org/cmd/gofmt/][gofmt]]. Możesz włączyć lub wyłączyć podświetlanie składni używając przycisku [[javascript:highlightAndClick(".syntax-checkbox")][syntax]].
 
 Gdy będziesz gotów by zacząć, naciśnij [[javascript:highlightAndClick(".next-page")][strzałka w prawo]] pod spodem lub wciśnij `PageDown`.
 
 .play welcome/hello.go
 
-* Go local
+* Go w lokalnych wersjach językowych
 
-Przewodnik po Go jest równierz dostępna w następujących językach:
+Przewodnik po Go jest również dostępna w następujących językach:
 
 - [[https://go-tour-br.appspot.com/][Brazilian Portuguese — Português do Brasil]]
 - [[https://go-tour-ca.appspot.com/][Catalan — Català]]
 - [[https://tour.go-zh.org/][Simplified Chinese — 中文（简体）]]
 - [[https://go-tour-cz.appspot.com/][Czech — Česky]]
+- [[https://tour.golang.org/welcome/1][English — English]]
 - [[https://go-tour-fr.appspot.com/][French — Français]]
 - [[https://go-tour-id2.appspot.com/][Indonesian — Bahasa Indonesia]]
 - [[https://go-tour-jp.appspot.com/][Japanese — 日本語]]
 - [[https://go-tour-ko.appspot.com/][Korean — 한국어]]
-- [[https://go-tour-pl1.ew.r.appspot.com/][Polish - Polski]]
-- [[https://go-tour-th.appspot.com/][Thai - ภาษาไทย]]
+- [[https://go-tour-pl1.appspot.com/][Polish — Polski]]
+- [[https://go-tour-th.appspot.com/][Thai — ภาษาไทย]]
 - [[https://go-tour-uz.appspot.com/][Uzbek — Ўзбекча]]
+
 
 Naciśnij przycisk [[javascript:highlightAndClick(".next-page")]["dalej"]] lub `PageDown` by kontynuować.
 
 #appengine: * Go offline (opcjonalne)
 #appengine:
-#appengine: Ten przewodnik jest równierz dostępny jako samodzielny program
-#appengine: bez dostępu do internetu.
-#appengine: 
+#appengine: Ten przewodnik jest również dostępny jako samodzielny program
+#appengine: nie wymagający dostępu do internetu.
 #appengine:
-#appengine: By go uruchomić go lokalnie, najpierw będziesz musiał
-#appengine: [[https://golang.org/doc/install][zainstalować Go]] i wtedy uruchomić poprzez:
+#appengine:
+#appengine: By uruchomić go lokalnie, będziesz musiał najpierw
+#appengine: [[https://golang.org/doc/install][zainstalować Go]], a następnie wykonać komendę:
 #appengine:
 #appengine:   go get golang.org/x/tour
 #appengine:
-#appengine: Puszczając wyżej wymienioną komendę, Przewodnik po Go zostanie pobrany i umieszczony w
-#appengine: [[https://golang.org/doc/code.html#Workspaces][workspace]] /`bin` folderze.
-#appengine: Gdy uruchomisz program, przeglądarka itnernetowa z twoją lokalną wersją Go otworzy się.
+#appengine: Po uruchomieniu powyższej komendy, Przewodnik po Go zostanie pobrana i umieszczona w folderze
+#appengine: [[https://golang.org/doc/code.html#Workspaces][workspace]] /`bin`.
+#appengine: Gdy uruchomisz program, przeglądarka otworzy się przeglądarka internetowa z twoją lokalną wersją Go.
 #appengine:
-#appengine: Oczywiście, możesz kontynuować z Wycieczką po Go używając tej strony!
+#appengine: Oczywiście, możesz kontynuować Przewodnik po Go używając tej strony!
 
 #appengine: * Go Playground
 #appengine:
-#appengine: Przewodnik po Go zbudowana jest na [[https://play.golang.org/][Go Playground]], który jest
+#appengine: Przewodnik po Go jest zbudowana na [[https://play.golang.org/][Go Playground]], który jest
 #appengine: serwisem webowym działającym na serwerach [[https://golang.org/][golang.org]].
 #appengine:
-#appengine: Serwis otrzymuje program Go, kompiluje go, linkuje, puszcza w
-#appengine: sanboxie, oraz zwraca rezultat.
+#appengine: Ten serwis odbiera program napisany w Go, kompiluje go, linkuje,
+#appengine: uruchamia w sandboxie, a następnie zwraca rezultat.
 #appengine:
-#appengine: Sa równierz ograniczenia na programach które mogą być puszczone w playgroundzie:
+#appengine: Istnieją pewne ograniczenia na programy które są uruchamiane w playgroundzie:
 #appengine:
-#appengine: - W playgroundzie czas zaczyna się od 2009-11-10 23:00:00 UTC (ustalenie dlaczego ta data jest ważna, pozostawione zostaje dla czytającego). To sprawia że łatwiej zachować programy w pamięci podręcznej po przez dawanie im deterministycznego rezultatu.
+#appengine: - W playgroundzie czas jest liczony od 2009-11-10 23:00:00 UTC (ustalenia znaczenia tej daty, pozostawiamy jako proste ćwiczenie dla czytelnika). Sprawia to, że rezultat działania programów jest deterministyczny, więc łatwiej jest przechowywać je w pamięci podręcznej (cashować).
 #appengine:
-#appengine: - Są równierz ograniczenia na czasie wykonania oraz na zużyciu procesora oraz pamięci, program nie może komunikować się z innymi komputerami.
+#appengine: - Istnieją również ograniczenia na czas wykonania się programu oraz wykorzystanie przez niego procesora i pamięci. Programy nie może również łączyć się z innymi komputerami.
 #appengine:
 #appengine: Playground używa najnowszej stabilnej wersji Go.
 #appengine:
-#appengine: Przeczytaj "[[https://blog.golang.org/playground][Inside the Go Playground]]" by dowiedzieć się więcej.
+#appengine: By dowiedzieć się więcej przeczytaj "[[https://blog.golang.org/playground][Inside the Go Playground]]".
 #appengine:
 #appengine: .play welcome/sandbox.go
 
@@ -100,5 +100,4 @@ Naciśnij przycisk [[javascript:highlightAndClick(".next-page")]["dalej"]] lub `
 
 Właśnie ukończyłeś swój pierwszy moduł Przewodnika po Go!
 
-Kliknij na [[javascript:highlightAndClick(".logo")][Przewodnik po Go]] by dowiedzieć się czego więcej możesz się nauczyć, 
-lub odrazu przejdź do [[javascript:click('.next-page')][kolejnej lekcji]].
+Kliknij na [[javascript:highlightAndClick(".logo")][Przewodnik po Go]] by dowiedzieć się czego więcej możesz się nauczyć, lub od razu przejdź do [[javascript:click('.next-page')][następnej lekcji]].

--- a/content/welcome.article
+++ b/content/welcome.article
@@ -1,18 +1,18 @@
 Witamy!
-Naucz się jak używać Przewodnika po Go: wliczając w to instrukcje jak poruszać się między lekcje oraz jak uruchomić kod.
+Naucz się jak używać Przewodnika po Go: wliczając w to instrukcje jak poruszać się między lekcjami oraz jak uruchomić kod.
 
 Autorzy Go
 https://golang.org
 
 * Cześć!
 
-Witamy na przewodniku po [[https://golang.org/][języku Go]].
+Witamy w przewodniku po [[https://golang.org/][języku Go]].
 
 Przewodnik jest podzielony na listę modułów do których możesz przejść
 klikając na logo
 [[javascript:highlight(".logo")][Przewodnik po Go]] w lewym górnym rogu ekranu.
 
-W dowolnym momencie możesz zobaczyć spis treści poprzez kliknięcie na [[javascript:highlightAndClick(".nav")][menu]] w prawym górnym rogu ekranu.
+W dowolnym momencie możesz zobaczyć spis treści przewodnika poprzez kliknięcie na [[javascript:highlightAndClick(".nav")][menu]] w prawym górnym rogu ekranu.
 
 W przewodniku po Go zapoznasz się z serią slajdów i ćwiczeń które będziesz mógł wykonać.
 
@@ -41,7 +41,7 @@ Gdy będziesz gotów by zacząć, naciśnij [[javascript:highlightAndClick(".nex
 
 * Go w lokalnych wersjach językowych
 
-Przewodnik po Go jest również dostępna w następujących językach:
+Przewodnik po Go jest również dostępny w następujących językach:
 
 - [[https://go-tour-br.appspot.com/][Brazilian Portuguese — Português do Brasil]]
 - [[https://go-tour-ca.appspot.com/][Catalan — Català]]
@@ -52,7 +52,6 @@ Przewodnik po Go jest również dostępna w następujących językach:
 - [[https://go-tour-id2.appspot.com/][Indonesian — Bahasa Indonesia]]
 - [[https://go-tour-jp.appspot.com/][Japanese — 日本語]]
 - [[https://go-tour-ko.appspot.com/][Korean — 한국어]]
-- [[https://go-tour-pl1.appspot.com/][Polish — Polski]]
 - [[https://go-tour-th.appspot.com/][Thai — ภาษาไทย]]
 - [[https://go-tour-uz.appspot.com/][Uzbek — Ўзбекча]]
 
@@ -72,7 +71,7 @@ Naciśnij przycisk [[javascript:highlightAndClick(".next-page")]["dalej"]] lub `
 #appengine:
 #appengine: Po uruchomieniu powyższej komendy, Przewodnik po Go zostanie pobrana i umieszczona w folderze
 #appengine: [[https://golang.org/doc/code.html#Workspaces][workspace]] /`bin`.
-#appengine: Gdy uruchomisz program, przeglądarka otworzy się przeglądarka internetowa z twoją lokalną wersją Go.
+#appengine: Gdy uruchomisz program, otworzy się przeglądarka internetowa z twoją lokalną wersją Go.
 #appengine:
 #appengine: Oczywiście, możesz kontynuować Przewodnik po Go używając tej strony!
 
@@ -82,7 +81,7 @@ Naciśnij przycisk [[javascript:highlightAndClick(".next-page")]["dalej"]] lub `
 #appengine: serwisem webowym działającym na serwerach [[https://golang.org/][golang.org]].
 #appengine:
 #appengine: Ten serwis odbiera program napisany w Go, kompiluje go, linkuje,
-#appengine: uruchamia w sandboxie, a następnie zwraca rezultat.
+#appengine: uruchamia go w sandboxie, a następnie zwraca rezultat.
 #appengine:
 #appengine: Istnieją pewne ograniczenia na programy które są uruchamiane w playgroundzie:
 #appengine:


### PR DESCRIPTION
Dzisiaj, jakimś sposobem, zrobiłem GitHubowego pulla, więc wersja powinna być aktualna.

W PR bardzo dużo zmian językowych, kilka ważniejszych punktów jest wymienionych powyżej. Wiele innych zapewne wyjdzie dopiero przy sprawdzaniu.

* Wszędzie w tekście „A Tour of Go” powinno być teraz tłumaczone jako „Przewodnik po Go”, acz nie zaszkodzi sprawdzić;
* Do listy różnych wersji językowych dodano link do angielskiego „A Tour of Go”.
* Idąc śladem polskich książek do C++ jakie czytałem, czyli pewnie jest to pomysł Jerzego Grębosza, tłumaczę „struct literals” nie jako „literały struktur” tylko jako „struktury literalne”. Analogicznie wprowadziłem „tablice literalne”, „wycinki literalne”, etc.
* Opierając się na artykule [_Go's Declaration Syntax_](https://blog.golang.org/declaration-syntax) dodałem moje rozumienie tego jak powinno się czytać `[]T`. Według mnie taki typ należy czytać „wycinek na tablicę o elementach typu T”, bo każdy wycinek musi wskazywać na jakąś tablicę, z wyjątkiem tych typu `nil`, ale ten przypadek możemy chyba pominąć. Jednak to jest tylko mój pomysł.
* Opierając się na artykułach [_Go Slices: usage and internals_](https://blog.golang.org/slices-intro) i [_Arrays, slices (and strings)..._](https://blog.golang.org/slices) pozwoliłem sobie przetłumaczyć „slice's underlying array” jako „tablicę na którą wskazuje wycinek”. Tłumaczenie jest dalekie od ideału, mam jednak nadzieję, że jest zgrabniejsze niż dotychczasowa wersja. Nie mogę znaleźć dobrego polskiego odpowiednika „underlying”, stąd problem.
* Tłumaczenie slajdu [Map literals continued](https://tour.golang.org/moretypes/21) stanowi wyzwanie. Ja rozumiem to tak, że „top-level type” oznacza typ `type2` w deklaracji mapy `map[type1]type2`, mogę się jednak mylić. Zaproponowałem tłumaczenie „Jeśli typ elementu zwracanego przez mapę jest po prostu nazwą typu, możesz pominąć w deklaracjach elementów mapy literalnej.”. Tekst ten brzmi tak sobie.
* Dużym problemem jest dla mnie tłumaczenie „function value”, choćby dlatego, że czym są wartości w Go rozumiem tylko intuicyjnie. Według mnie to oznacza, że sama funkcja jest wartością w sensie języka Go i tu się pojawia problem. Tłumaczenie „function value” na „wartości funkcji” uważam za błędne, bo w języku polski wartości funkcji to to co dana funkcja zwraca, nie zaś sama funkcja. Użyłem długaśnego tłumaczenia „funkcje będące wartościami”.
* Opierając się na wystąpieniu [_Understanding_ `nil`](https://www.youtube.com/watch?v=ynoY2xz-F8s) i podanej tam informacji, że według specyfikacji Go `nil` to „predefined identifier” (nawet nie próbuję tego przetłumaczyć) nie posiadający typu, zaproponowałem by wszędzie w „Przewodniu po Go” nie tłumaczyć słowa „nil” na polski jako „pusty”, czy jakoś inaczej, tylko zostawić jako `nil`. To trochę kontrowersyjny ruch, ale wydaje mi się warto rozważenia.
* Tłumaczenie terminów związanych z interfejsami sprawiło mi dużo trudności, moje tłumaczenie tej części uważam za pozostawiające wiele do życzenia.
* W opisie czytników ([Readers](https://tour.golang.org/methods/21)) napisałem, że metoda `Read` zapełnia wycinek wskazujący na tablicę bajtów (może lepiej: wycinek bajtów), gdyż wedle informacji na tej [stronie](https://tour.golang.org/basics/11) w Go `byte` jest tylko aliasem typu `uint8`.
* Nie znam się na runtime w Go, jednak wpis w [Go FAQ](https://golang.org/doc/faq#runtime) sugeruje mi, że przez „runtime” w Go zawsze rozumie się pewną bibliotekę będącą częścią biblioteki standardowej. Dlatego tłumaczyłem odpowiednik tego [slajdu](https://tour.golang.org/concurrency/1) pozostawiłem „runtime” po angielsku.
* Mam bardzo pobieżne rozumienie współbieżności, więc wiele rzeczy w module „Concurrency” musiałem tłumaczyć na wyczucie. Choć tłumaczenia mogą być błędne, mam nadzieję, że będą stanowić dobry punkt wyjścia do innych poprawek.